### PR TITLE
Add default admin password documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,4 +109,6 @@
     $ php ezpublish/console ezplatform:install --env prod demo-clean
     ```
 
+    **Note**: Password for the generated `admin` user is `publish`, this name and password is needed when you would like to login to backend Platform UI. Future versions will prompt you for a unique password during installion.
+
 You can now point your browser to the installation and browse the site. To access the Platform UI backend, use the `/shell` URL.


### PR DESCRIPTION
Hello eZ Platform People!

We recently helped a co-worker who was new to eZ Platform solve an issue that may seem trivial to the more experienced eZ Publish developers. 

In short, it was unclear (at the time) to our friend what upon a new default installation and setup of eZ Platform, the default admin user password was.

Re: http://share.ez.no/forums/ez-publish-5-platform/ez-platform-backend

We've also found that many users, even experienced eZ Publish users are not yet 100% clear as to the real differences between eZ Platform and eZ Publish and as such we find we have to do a fair amount of educating users who often ignore eZ Publish documentation (even on doc.ez.no confluence) because it says eZ Publish instead of eZ Platform.

While we know this will given more time (this is just the first alpha1 of eZ Platform) that the documentation will be more distinct and clear, we thought that we would try to help users today by clearing up what might be one of the first questions they might have after installing eZ Platform.

Which brings us all to our first true eZ Platform pull request to clarify and clearly document the default (admin) user and password in eZ Platform.

By adding this documentation in the INSTALL.md source code documentation we believe we will be able to help prevent this question from needing to be asked again so quickly and allow users to get started using eZ Platform right away. Though it would be even more helpful if future doc.ez.no documentation (exclusively) on eZ Platform also include a similar explanation. 

Note: Noting our above mention on distinct documentation for eZ Platform, We realize this is in fact already very clearly documented in older 'eZ Publish' (Legacy) documentation, https://doc.ez.no/display/EZP/Manual+configuration+of+eZ+Publish#ManualconfigurationofeZPublish-Administrator'slog-inandpassword

Please let us know your thoughts!
Thank you for your continued support!

Cheers,
Brookins Consulting