### PR TITLE
Fix EZP-24311: Clarify the differences between ezpublish-community and ezplatform repositories in README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 eZ Platform is the 6th generation of eZ Publish, it is built on top of Symfony framework (Full Stack).
 It has been in development since 2011, and official part of the eZ Publish Platform 5.x as "Platform stack" since 2012. 
 
+## eZ Publish / eZ Platform
+This repository contains the eZ Platform (formerly eZ Publish 6) the next generation cms which uses the same Symfony kernel as eZ Publish 5, but does not include the legacy application, nor the dependent libraries. eZ Platform is where the new features are added.
+
+The [eZ Publish 5](https://github.com/ezsystems/ezpublish-community) repository, mostly maintained for backwards compatibility, integrates eZ Publish Legacy.
+
 ### Abstract:
 - **Very extensible** *You can extend the application and the content model many ways*
 - **Future & backwards compatible** *Strong BC policy on data as well as code*


### PR DESCRIPTION
Hello,

Related issue for these pull requests: https://jira.ez.no/browse/EZP-24311

Per request from Andre to update the repository README.md documentation to clarify the differences between the older ezpublish-community repository and the new ezplatform repository in order to re-start community builds for the 5.x branch we are creating this issue.

Goal: Clarify the differences between the older ezpublish-community repository and the new ezplatform repository in repository README.md documentation.

To achieve this goal we will update the README.md documentation in each repository via separate pull requests to explain the main difference (today) between each repository is the inclusion or exclusion of legacy dependencies by default.


This pull request addresses the issue in question for this repository.
Another pull request exists for the other repository.
See issue ticket for alternate pull request links.

Please let us know how this finds you.

Thank you again for your continued support.

Cheers,
Brookins Consulting