### PR TITLE
Fix EZP-24158: Need to clear cache manually after platform install

### DIFF
--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -5,6 +5,10 @@
 echo "> Setup github auth key to not reach api limit"
 ./bin/.travis/install_composer_github_key.sh
 
+echo "> Set folder permissions"
+sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 777
+sudo find {ezpublish/{cache,logs,config,sessions},web} -type f | sudo xargs chmod -R 666
+
 echo "> Copy behat specific parameters.yml settings"
 cp bin/.travis/parameters.yml ezpublish/config/
 
@@ -13,18 +17,11 @@ composer install -n --prefer-dist
 
 if [ "$INSTALL" = "demoContentNonUniqueDB" ] ; then
   echo "> Install ezplatform demo-content"
-  php ezpublish/console ezplatform:install demo
+  php ezpublish/console ezplatform:install --env=behat --no-debug demo
 else
   echo "> Install ezplatform clean"
-  php ezpublish/console ezplatform:install clean
+  php ezpublish/console ezplatform:install --env=behat --no-debug clean
 fi
 
-echo "> Set folder permissions"
-sudo find {ezpublish/{cache,logs,config,sessions},web} -type d | sudo xargs chmod -R 777
-sudo find {ezpublish/{cache,logs,config,sessions},web} -type f | sudo xargs chmod -R 666
-
 echo "> Run assetic dump for behat env"
-php ezpublish/console --env=behat assetic:dump
-
-echo "> Clear and warm up caches for behat env"
-php ezpublish/console cache:clear --env=behat --no-debug
+php ezpublish/console --env=behat --no-debug assetic:dump

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -115,7 +115,8 @@ class EzPublishKernel extends Kernel
         $loader->load( __DIR__ . '/config/config_' . $environment . '.yml' );
         $configFile = __DIR__ . '/config/ezpublish_' . $environment . '.yml';
 
-        if ( !is_file( $configFile ) )
+        // if config file or base config file is missing, then install is not done yet
+        if ( !is_file( $configFile ) || !is_file( __DIR__ . '/config/ezpublish.yml' ) )
         {
             $configFile = __DIR__ . '/config/ezpublish_setup.yml';
         }


### PR DESCRIPTION
Testing if https://github.com/ezsystems/ezpublish-kernel/pull/1244 also can remove need for manual cache clar on travis, hence be tested by behat tests.


*This cleans up some issues that was created when we introduced installer here in terms of having to do custom stuff for behat which with the kernel change here and the one in ezpublish-kernel is no longer needed.*

- [x] amend away composer.json change when kernel pr has been merged