### PR TITLE
Added wd_host setting for the Selenium2 driver

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,7 +5,8 @@ default:
         Behat\MinkExtension:
             base_url: 'http://localhost'
             goutte: ~
-            selenium2: ~
+            selenium2:
+                wd_host: 'http://localhost:4444/wd/hub'
             javascript_session: selenium2
             browser_name: firefox
 


### PR DESCRIPTION
This PR exposes in behat.yml.dist the setting for specifying host where selenium is running