### PR TITLE
Added behat-junit-formatter dependency to composer.json

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -18,6 +18,10 @@ default:
                 env: behat
                 debug: false
 
+        jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+            filename: report.xml
+            outputDir: %paths.base%/build/tests
+
     # default profile: no suites
     suites: ~
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,12 @@
             "homepage": "https://github.com/ezsystems/ezplatform/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:vidarl/behat-junit-formatter.git"
+        }
+    ],
     "replace": {
         "ezsystems/ezpublish-community": "*"
     },
@@ -47,6 +53,7 @@
         "behat/mink-extension": "*",
         "behat/mink-goutte-driver": "*",
         "behat/mink-selenium2-driver": "*",
+        "jarnaiz/behat-junit-formatter": "dev-undefined_sentences",
         "ezsystems/behatbundle": "@dev"
     },
     "suggest": {


### PR DESCRIPTION
This PR makes it possible to export results of behat tests in jUnit format, which is applicable when running tests from for instance jenkins.

Unfortunately, the jarnaiz/behat-junit-formatter do not deal with scenarios which contains undefined sentences ( which currently happen to exists our behat tests ). Thus, the custom package  repository...

