### PR TITLE
Use SYMFONY_ENV for consistency

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -4,7 +4,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // Environment is taken from "ENVIRONMENT" variable, if not set, defaults to "prod"
-$environment = getenv('ENVIRONMENT');
+$environment = getenv('SYMFONY_ENV');
 if ($environment === false) {
     $environment = 'prod';
 }


### PR DESCRIPTION
The name of the environment variable isn't consistent. Renaming all occurences to SYMFONY_ENV.