### PR TITLE
Added behat-junit-formatter dependency to composer.json

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -18,6 +18,10 @@ default:
                 env: behat
                 debug: false
 
+        jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+            filename: report.xml
+            outputDir: %paths.base%/build/tests
+
     # default profile: no suites
     suites: ~
 

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "behat/mink-extension": "*",
         "behat/mink-goutte-driver": "*",
         "behat/mink-selenium2-driver": "*",
+        "jarnaiz/behat-junit-formatter": "^1.3",
         "ezsystems/behatbundle": "@dev"
     },
     "suggest": {


### PR DESCRIPTION
This PR makes it possible to export results of behat tests in jUnit format, which is applicable when running tests from for instance jenkins.

This PR is quite similar to https://github.com/ezsystems/ezplatform/pull/41, except that we no longer need a custom package repository has https://github.com/j-arnaiz/behat-junit-formatter/pull/10 has  been merged.