### PR TITLE
Make Behat JUnitFormatter use writable folder

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -20,7 +20,7 @@ default:
 
         jarnaiz\JUnitFormatter\JUnitFormatterExtension:
             filename: report.xml
-            outputDir: %paths.base%/build/tests
+            outputDir: %paths.base%/ezpublish/logs/junit
 
     # default profile: no suites
     suites: ~


### PR DESCRIPTION
Tests for Platform UI uncovered that "build/tests" is a non existing and non writable folder out of the box, so changing it to use a writable one (ezpublish/logs/junit) to avoid issues with this.

/cc @vidarl 