### PR TITLE
[Behat] Add vhost alias for web, selenium & db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
   - PROFILE="rest" TEST="fullJson"
   - PROFILE="rest" TEST="fullXml"
 
+# host aliases for behat tests to be able to align config and scripts for future docker changes
+addons:
+  hosts: [web, selenium, db]
 
 # test only master (+ Pull requests)
 branches:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -3,10 +3,10 @@
 default:
     extensions:
         Behat\MinkExtension:
-            base_url: 'http://localhost'
+            base_url: 'http://web'
             goutte: ~
             selenium2:
-                wd_host: 'http://localhost:4444/wd/hub'
+                wd_host: 'http://selenium:4444/wd/hub'
             javascript_session: selenium2
             browser_name: firefox
 
@@ -50,21 +50,21 @@ rest:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
+                    url: http://web/api/ezp/v2/
                     driver: BuzzDriver
                     type: json
         fullXml:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
+                    url: http://web/api/ezp/v2/
                     driver: BuzzDriver
                     type: xml
         guzzle:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
+                    url: http://web/api/ezp/v2/
                     driver: GuzzleDriver
                     type: json
 
@@ -80,7 +80,7 @@ demo:
 legacyAdmin:
     extensions:
         Behat\MinkExtension:
-            base_url: http://localhost/behat_site_admin
+            base_url: http://web/behat_site_admin
     suites:
         full:
             paths: [ vendor/ezsystems/legacy-bridge/bundle/Features/Admin ]

--- a/bin/.travis/configure_apache2.sh
+++ b/bin/.travis/configure_apache2.sh
@@ -4,6 +4,7 @@
 sudo php bin/.travis/generatevhost.php \
          --basedir=$TRAVIS_BUILD_DIR \
          --env=behat \
+         --host_alias=web \
          doc/apache2/vhost.template \
          /etc/apache2/sites-available/behat
 sudo cp bin/.travis/apache2/php5-fcgi /etc/apache2/conf.d/php5-fcgi


### PR DESCRIPTION
To align with naming in containers to avoid complex, unnecessary, failure-prone config file patching there. 

*Note: `web` implies entry point selenium should run against.*

When passing:
- add host aliases on all repos that uses behat testing via travis
 - [ ] kernel
 - [ ] platform ui (PR)
 - [ ] demo
 - [ ] behat bundle 
- alternative to list of changes above would be to add hosts in selenium init scripts.