### PR TITLE
Fix EZP-24915: Solr Search Engine repository structure cleanup

### DIFF
--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -49,7 +49,7 @@ class EzPublishKernel extends Kernel
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
             new EzSystems\PrivacyCookieBundle\EzSystemsPrivacyCookieBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
-            new eZ\Bundle\EzPublishSolrSearchEngineBundle\EzPublishSolrSearchEngineBundle(),
+            new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
         );
 
         switch ($this->getEnvironment()) {


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24915

Corresponding PRs:
* https://github.com/ezsystems/ezplatform-solr-search-engine/pull/24
* ezsystems/ezpublish-kernel#1452
* https://github.com/ezsystems/ezpublish-platform/pull/18
* https://github.com/ezsystems/ezpublish-community/pull/250

This updates `EzPublishKernel.php` for the changed namespace of the Solr Search Engine bundle.