### PR TITLE
BDD: Moved core/rest configs to imports

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,5 +1,4 @@
 # This file contains the default configuration for behat testing using EzSystems/BehatBundle
-
 default:
     extensions:
         Behat\MinkExtension:
@@ -25,59 +24,8 @@ default:
     # default profile: no suites
     suites: ~
 
-platformui:
-      suites:
-          standard:
-              paths: [ vendor/ezsystems/platform-ui-bundle/Features/Standard ]
-              contexts:
-                  - EzSystems\PlatformUIBundle\Features\Context\PlatformUI:
-                      uri: /ez
-          CopyMoveDelete:
-              paths: [ vendor/ezsystems/platform-ui-bundle/Features/CopyMoveDelete ]
-              contexts:
-                  - EzSystems\PlatformUIBundle\Features\Context\PlatformUI:
-                      uri: /ez
-
-core:
-    suites:
-        console:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Console]
-            contexts: [ eZ\Bundle\EzPublishCoreBundle\Features\Context\ConsoleContext ]
-        # Web features (controllers, default templates, rendering features...)
-        web:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Content]
-            contexts: [ eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext ]
-
-
-rest:
-    suites:
-        fullJson:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts:
-                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
-                    driver: BuzzDriver
-                    type: json
-        fullXml:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts:
-                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
-                    driver: BuzzDriver
-                    type: xml
-        guzzle:
-            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
-            contexts:
-                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
-                    driver: GuzzleDriver
-                    type: json
-
-demo:
-    suites:
-        content:
-            paths: [ vendor/ezsystems/demobundle/EzSystems/DemoBundle/Features/Content ]
-            contexts: [ EzSystems\DemoBundle\Features\Context\Content\Context ]
-        clean:
-            paths: [ vendor/ezsystems/demobundle/EzSystems/DemoBundle/Features/Clean ]
-            contexts: [ EzSystems\DemoBundle\Features\Context\Demo ]
+imports:
+    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/behat.yml
+    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/behat.yml
+    - vendor/ezsystems/platform-ui-bundle/behat.yml
+    - vendor/ezsystems/demobundle/EzSystems/DemoBundle/behat.yml


### PR DESCRIPTION
> Related pull-requests: https://github.com/ezsystems/ezpublish-kernel/pull/1464, https://github.com/ezsystems/DemoBundle/pull/187, https://github.com/ezsystems/PlatformUIBundle/pull/378.

This moves profiles and suites away `behat.yml.dist` to the bundle they actually cover.

It allows any PR author to update the behat suites / contexts for a PR on any of the covered bundles without creating another PR to ezplatform.

The REST one contains a configuration bonus.