### PR TITLE
BDD: Added behat routing file + BehatBundle routes

### DIFF
--- a/ezpublish/config/config_behat.yml
+++ b/ezpublish/config/config_behat.yml
@@ -1,3 +1,7 @@
+framework:
+    router:
+        resource: "%kernel.root_dir%/config/routing_behat.yml"
+
 imports:
     - { resource: config_dev.yml }
 

--- a/ezpublish/config/routing_behat.yml
+++ b/ezpublish/config/routing_behat.yml
@@ -1,0 +1,5 @@
+_main:
+    resource: routing_dev.yml
+
+_ezplatform_behat:
+    resource: "@EzPlatformBehatBundle/Resources/config/routing.yml"


### PR DESCRIPTION
In `behat` env, the routing.yml file from `@EzSystemsPlatformBehatBundle` is loaded. It contains routes used in behat scenarii.

The (empty) file has already been merged into ezpublish-kernel@master.