### PR TITLE
Implement EZP-24925: Extract XmlText field type out of kernel into separate repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "ezsystems/repository-forms": "~1.0.0@dev",
         "ezsystems/ezplatform-solr-search-engine": "~1.0.0@dev",
+        "ezsystems/ezplatform-xmltext-fieldtype": "~1.0.0@dev",
         "ezsystems/platform-ui-bundle": "~1.0.0@dev",
         "ezsystems/platform-ui-assets-bundle": "~1.0.0@dev",
         "ezsystems/demobundle": "~6.0@dev",

--- a/ezpublish/EzPublishKernel.php
+++ b/ezpublish/EzPublishKernel.php
@@ -50,6 +50,7 @@ class EzPublishKernel extends Kernel
             new EzSystems\PrivacyCookieBundle\EzSystemsPrivacyCookieBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
+            new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),
         );
 
         switch ($this->getEnvironment()) {


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24925

This adds `ezsystems/ezplatform-xmltext-fieldtype` to `composer.json` and registers its bundle with kernel.