### PR TITLE
Disabling Stash Tracking in example config

### DIFF
--- a/ezpublish/config/ezpublish.yml.example
+++ b/ezpublish/config/ezpublish.yml.example
@@ -12,6 +12,7 @@ doctrine:
 
 # Stash is used for persistence cache
 stash:
+    tracking: false # enables query logging
     caches:
         default:
             drivers:

--- a/ezpublish/config/ezpublish.yml.example
+++ b/ezpublish/config/ezpublish.yml.example
@@ -12,7 +12,7 @@ doctrine:
 
 # Stash is used for persistence cache
 stash:
-    tracking: false # enables query logging
+    tracking: false # disables query logging
     caches:
         default:
             drivers:


### PR DESCRIPTION
Stash tracking (http://www.stashphp.com/Symfony.html#tracking) in development mode fills up the disk when working with large numbers of content. It is also not very crucial during for developers creating sites with eZ Platform, so I suggest disabling it by default.