### PR TITLE
Disable Stash cache value tracking by default

### DIFF
--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -26,3 +26,6 @@ php ezpublish/console --env=behat --no-debug assetic:dump
 
 echo "> Installing ezplatform clean"
 php ezpublish/console --env=behat ezplatform:install clean
+
+echo "> Warm up cache, using curl to make sure everything is warmed up, incl class, http & spi cache"
+curl -sSLI "http://localhost"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "sensio/distribution-bundle": "~3.0",
         "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0",
-        "tedivm/stash-bundle": "0.4.*",
+        "tedivm/stash-bundle": "~0.4.3",
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "ezsystems/repository-forms": "~1.0.0@dev",
         "ezsystems/ezplatform-solr-search-engine": "~1.0.0@dev",

--- a/ezpublish/config/config.yml
+++ b/ezpublish/config/config.yml
@@ -45,6 +45,8 @@ stash:
             # you need to change the keyHashFunction used to generate cache directories to "crc32"
             # FileSystem:
             #    keyHashFunction: crc32
+    # Disable tracking of cache values to avoid large disk use when using web profiler
+    tracking_values: false
 
 framework:
     esi:             ~


### PR DESCRIPTION
replaces / closes #66 

Should speed up things in dev env a bit, in addition to avoiding disk the issue with large disk use by profiler files. Very optimistic, but might be it gets rid of the strange issues some people have with profiler not loading, but that would be just to much of a luck :)