### PR TITLE
Removed xmltext fieldtype

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -45,7 +45,6 @@ class AppKernel extends Kernel
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
-            new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),
             new AppBundle\AppBundle(),
         );
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "ezsystems/repository-forms": "~1.0.0@dev",
         "ezsystems/ezplatform-solr-search-engine": "~1.0.0@dev",
-        "ezsystems/ezplatform-xmltext-fieldtype": "~1.0.0@dev",
         "ezsystems/platform-ui-bundle": "~1.0.0@dev",
         "ezsystems/platform-ui-assets-bundle": "~1.0.0@dev",
         "egulias/listeners-debug-command-bundle": "~1.9",


### PR DESCRIPTION
> Part of https://jira.ez.no/browse/EZP-24925

Not part of ezplatform by default, but can be installed separately from http://packagist.org/packages/ezsystems/ezplatform-xmltext-fieldtype.