### PR TITLE
Set package type to "project"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "eZ Platform distribution",
     "homepage": "https://github.com/ezsystems/ezplatform",
     "license": "GPL-2.0",
+    "type": "project",
     "authors": [
         {
             "name": "eZ dev-team & eZ Community",


### PR DESCRIPTION
eZ Platform is a project/application, not "just" a library… Well, that's a massive PR for once :smile: 