### PR TITLE
EZP-25314: Add misc Symfony files, web/css and web/js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /.idea/
 /bin/behat
 /bin/phpunit
+/app/check.php
+/app/SymfonyRequirements.php
 /app/cache/
 /app/logs/
 /ezpublish_legacy
@@ -13,6 +15,8 @@
 /web/index_rest.php
 /web/index_cluster.php
 /web/bundles/
+/web/css/
+/web/js/
 /web/design
 /web/extension
 /web/share


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25314

`app/check.php` and `app/SymfonyRequirements.php` are (re)generated by Symfony when installing/updating vendors, so they're not too useful to be in the repo.

`web/css` and `web/js` folders are also (re)generated when installing/updating vendors, by Assetic.