### PR TITLE
[Security][Travis] Update approach for github token to same as symfony uses

### DIFF
--- a/bin/.travis/composer-auth.json
+++ b/bin/.travis/composer-auth.json
@@ -1,0 +1,8 @@
+{
+    "github-oauth": {
+        "github.com": "PLEASE DO NOT USE THIS TOKEN IN YOUR OWN PROJECTS/FORKS",
+        "github.com": "This token is reserved for testing with ezsystems repositories",
+        "github.com": "NB: You create your own token without(!) any scope to use same approach",
+        "github.com": "d0285ed5c8644f30547572ead2ed897431c1fc09"
+    }
+}

--- a/bin/.travis/install_composer_github_key.sh
+++ b/bin/.travis/install_composer_github_key.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# This is unfortunately only way to avoid Github API limits with Travis on an open source project.
-# Please don't use our token, neither token nor it's user gives access to anything other then authentication, so better if you create your own.
-# PS: The simple obfuscation here is only to avoid Github from detecting this on commits.
-export EZ_GITHUB_TOKEN_A=`echo "574503f4468c5de5820d" | rev`
-export EZ_GITHUB_TOKEN_B=`echo "90cf1c134798de2dae27" | rev`
-
-composer config -g github-oauth.github.com "${EZ_GITHUB_TOKEN_A}${EZ_GITHUB_TOKEN_B}"

--- a/bin/.travis/prepare_ezpublish.sh
+++ b/bin/.travis/prepare_ezpublish.sh
@@ -6,7 +6,7 @@ echo "> prefer ip4 to avoid packagist.org composer issues"
 sudo sh -c "echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf"
 
 echo "> Setup github auth key to not reach api limit"
-./bin/.travis/install_composer_github_key.sh
+cp bin/.travis/composer-auth.json ~/.composer/auth.json
 
 echo "> Set folder permissions"
 sudo find {app/{cache,logs},web} -type d | sudo xargs chmod -R 777
@@ -15,11 +15,15 @@ sudo find {app/{cache,logs},web} -type f | sudo xargs chmod -R 666
 echo "> Copy behat specific parameters.yml settings"
 cp bin/.travis/parameters.yml app/config/
 
-# Switch to another Symfony version if asked for
-if [ "$SYMFONY_VERSION" != "" ] ; then composer require --no-update symfony/symfony="$SYMFONY_VERSION" ; fi;
-
-echo "> Install dependencies through composer"
-composer install --no-progress --no-interaction
+# Switch to another Symfony version if asked for (with composer update to not use composer.lock if present)
+if [ "$SYMFONY_VERSION" != "" ] ; then
+    echo "> Install dependencies through Composer (with custom Symfony version: ${SYMFONY_VERSION})"
+    composer require --no-update symfony/symfony="${SYMFONY_VERSION}"
+    composer update --no-progress --no-interaction --prefer-dist
+else
+    echo "> Install dependencies through Composer"
+    composer install --no-progress --no-interaction --prefer-dist
+fi
 
 echo "> Run assetic dump for behat env"
 php app/console --env=behat --no-debug assetic:dump


### PR DESCRIPTION
The [symfony approach](https://github.com/symfony/symfony/commit/6215437bdd6d6fc67ee167aea5e88324117be668) is more straight forward, and avoids setting a bad example for others *(risking they create tokens with a scope without being protected by githubs commit token scanners, unintentionally exposing rights to their repos)*.

This issue was reported by @ChALkeR as a possible security risk for us and especially downstream projects. *Note: The user connected to the token in question afaik never had membership rights on any of our repositories, however it had a scope enabled so if user by mistake would have had access to anything, then so would the token. The approach here is thus safer, as Gitub will automatically revoke any tokens they detect with scopes that pose a direct security risk.* 