### PR TITLE
Added missing behatbundle behat.yml to behat.yml.dist

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -27,4 +27,5 @@ default:
 imports:
     - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/behat.yml
     - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/behat.yml
+    - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/behat.yml
     - vendor/ezsystems/platform-ui-bundle/behat.yml

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -25,7 +25,7 @@ default:
     suites: ~
 
 imports:
-    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/behat.yml
-    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/behat.yml
-    - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/behat.yml
-    - vendor/ezsystems/platform-ui-bundle/behat.yml
+    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
+    - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/behat_suites.yml
+    - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/behat_suites.yml
+    - vendor/ezsystems/platform-ui-bundle/behat_suites.yml


### PR DESCRIPTION
As discussed in the [travis fix PR](https://github.com/ezsystems/BehatBundle/pull/42) added the missing behat.yml to behat.yml.dist