### PR TITLE
Fixed so that bin/vhost.sh correctly disables prod rewrite rules in dev mode in nginx vhost

### DIFF
--- a/bin/vhost.sh
+++ b/bin/vhost.sh
@@ -28,6 +28,7 @@ template_vars=(${option_vars[*]})
 template_vars+=("%BODY_SIZE_LIMIT_M%")
 template_vars+=("%TIMEOUT_S%")
 template_vars+=("%HOST_LIST%")
+template_vars+=("%INCLUDE_PROD_REWRITE_RULES%")
 
 # Default options
 declare -a template_values=(
@@ -220,6 +221,12 @@ if [[ "${template_values[4]}" != "" ]] ; then
      template_values[16]=$tmp
 fi
 
+# Decide whatwever to include prod rewrite rules based on template_values[5] (SYMFONY_ENV)
+if [ "${template_values[5]}" == "dev" ]; then
+    template_values[17]="#include ez_params.d/ez_prod_rewrite_params;"
+else
+    template_values[17]="include ez_params.d/ez_prod_rewrite_params;"
+fi
 
 ## Generate template result and output
 

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -8,8 +8,10 @@ server {
 
     # Additional Assetic rules for eZ Publish 5.1 / 2013.4 and higher.
     ## Don't forget to run php app/console assetic:dump --env=prod
-    ## and make sure to comment these out in DEV environment.
-    include ez_params.d/ez_prod_rewrite_params;
+    ## You need the following rewrite rule enabled in PROD environment, but disabled in DEV environment.
+    #include ez_params.d/ez_prod_rewrite_params;
+    # With the line below we let bin/vhost.sh controll if the rewrite rule should be enabled or not
+    %INCLUDE_PROD_REWRITE_RULES%
 
     # Cluster/streamed files rewrite rules. Enable on cluster with DFS as a binary data handler
     #rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/app.php" break;


### PR DESCRIPTION

In doc/nginx/vhost.template we have

    ## and make sure to comment these out in DEV environment.
    ## You need the following rewrite rule enabled in PROD environment, but disabled in DEV environment.
    include ez_params.d/ez_prod_rewrite_params;

This causes the the prod rewrite rules to still be included when generating the vhost using ```bin/vhost.sh (...) --sf-env=dev```

This PR fixes this problem