### PR TITLE
[travis] removed -v option from behat command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 # execute behat as the script command
 script:
-  - php bin/behat -vc behat.yml.dist $ARGS --tags='~@broken'
+  - php bin/behat -c behat.yml.dist $ARGS --tags='~@broken'
 
 # disable mail notifications
 notifications:


### PR DESCRIPTION
Causes an error on builds, with no specs being found.
See https://travis-ci.org/ezsystems/ezplatform/builds/116877568.