### PR TITLE
[Behat] Remove Behat failure on deprecation warnings

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,5 +1,7 @@
 # This file contains the default configuration for behat testing using EzSystems/BehatBundle
 default:
+    calls:
+        error_reporting: 14335 # E_ALL & ~E_USER_DEPRECATED
     extensions:
         Behat\MinkExtension:
             base_url: 'http://localhost'


### PR DESCRIPTION
This PR configures Behat so it does not fail when a E_ALL and ~E_USER_DEPRECATED php error occur.