### PR TITLE
Fix EZP-25638: Editing content types when default siteaccess only uses nor-NO as language

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -23,4 +23,7 @@ ezpublish:
             # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
             # need to manually modify your database data to reflect this to avoid exceptions.
             var_dir: var/site
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             languages: [eng-GB]


### PR DESCRIPTION
> Doc fix for https://jira.ez.no/browse/EZP-25638
> Status: Ready for review

In the immortal words of Boromir: "One does not simply remove eng-GB from the site languages list."