### PR TITLE
Remove unused system_info_view route

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -45,6 +45,7 @@ class AppKernel extends Kernel
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
+            new EzSystems\EzSupportToolsBundle\EzSystemsEzSupportToolsBundle(),
             new AppBundle\AppBundle(),
         );
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -26,6 +26,3 @@ _ezpublishPlatformUIRoutes:
 
 _ezplatformRepositoryFormsRoutes:
     resource: "@EzSystemsRepositoryFormsBundle/Resources/config/routing.yml"
-
-_ezSupportToolsRoutes:
-    resource: "@EzSystemsEzSupportToolsBundle/Resources/config/routing.yml"

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -26,3 +26,6 @@ _ezpublishPlatformUIRoutes:
 
 _ezplatformRepositoryFormsRoutes:
     resource: "@EzSystemsRepositoryFormsBundle/Resources/config/routing.yml"
+
+_ezSupportToolsRoutes:
+    resource: "@EzSystemsEzSupportToolsBundle/Resources/config/routing.yml"

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,14 @@
         "ezsystems/ezpublish-kernel": "~6.2@dev",
         "ezsystems/repository-forms": "~1.1@dev",
         "ezsystems/ezplatform-solr-search-engine": "~1.0@dev",
-        "ezsystems/platform-ui-bundle": "~1.2@dev",
+        "ezsystems/platform-ui-bundle": "dev-ezp25653_use_ezsupporttools_in_platformui as v1.3.0-dev",
         "egulias/listeners-debug-command-bundle": "~1.9",
         "white-october/pagerfanta-bundle": "1.0.*",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "symfony/expression-language": "~2.4",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "ezsystems/ez-support-tools": "v0.1.0-dev"
     },
     "require-dev": {
         "behat/behat": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
         "ezsystems/ezpublish-kernel": "~6.2@dev",
         "ezsystems/repository-forms": "~1.1@dev",
         "ezsystems/ezplatform-solr-search-engine": "~1.0@dev",
-        "ezsystems/platform-ui-bundle": "dev-ezp25653_use_ezsupporttools_in_platformui as v1.3.0-dev",
+        "ezsystems/platform-ui-bundle": "dev-dev-ezp25653_use_ezsupporttools_in_platformui as v1.3.0-dev",
         "egulias/listeners-debug-command-bundle": "~1.9",
         "white-october/pagerfanta-bundle": "1.0.*",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "symfony/expression-language": "~2.4",
         "sensio/framework-extra-bundle": "~3.0",
-        "ezsystems/ez-support-tools": "v0.1.0-dev"
+        "ezsystems/ez-support-tools": "~0.1.0@dev"
     },
     "require-dev": {
         "behat/behat": "~3.0",


### PR DESCRIPTION
> Fixing issue found in https://jira.ez.no/browse/EZP-25653, PR against https://github.com/ezsystems/ezplatform/pull/104
> See also: ez-support-tools PR: https://github.com/ezsystems/ez-support-tools/pull/16
> Status: Ready for review

The system_info_view route is not used, and has no access control, this removes it.