### PR TITLE
Prepare distribution for container use

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: default_parameters.yml }
     - { resource: parameters.yml }
     - { resource: security.yml }
+    - { resource: env.php }
 
 # Configuration for Database connection, can have several connections used by eZ Repositories in ezplatform.yml
 doctrine:

--- a/app/config/env.php
+++ b/app/config/env.php
@@ -1,0 +1,67 @@
+<?php
+// On Symfony container compilation*, reads parameters from env variables if defined and overrides the yml parameters.
+// * For typical use cases like Docker, make sure to recompile Symfony container on run to refresh settings.
+
+if ($value = getenv('SYMFONY_SECRET')) {
+    $container->setParameter('secret', $value);
+}
+
+// Mailer settings
+if ($value = getenv('MAILER_TRANSPORT')) {
+    $container->setParameter('mailer_transport', $value);
+}
+
+if ($value = getenv('MAILER_HOST')) {
+    $container->setParameter('mailer_host', $value);
+}
+
+if ($value = getenv('MAILER_USER')) {
+    $container->setParameter('mailer_user', $value);
+}
+
+if ($value = getenv('MAILER_PASSWORD')) {
+    $container->setParameter('mailer_password', $value);
+}
+
+// Database settings
+if ($value = getenv('DATABASE_DRIVER')) {
+    $container->setParameter('database_driver', $value);
+}
+
+if ($value = getenv('DATABASE_HOST')) {
+    $container->setParameter('database_host', $value);
+}
+
+if ($value = getenv('DATABASE_PORT')) {
+    $container->setParameter('database_port', $value);
+}
+
+if ($value = getenv('DATABASE_NAME')) {
+    $container->setParameter('database_name', $value);
+}
+
+if ($value = getenv('DATABASE_USER')) {
+    $container->setParameter('database_user', $value);
+}
+
+if ($value = getenv('DATABASE_PASSWORD')) {
+    $container->setParameter('database_password', $value);
+}
+
+// Search Engine settings
+if ($value = getenv('SEARCH_ENGINE')) {
+    $container->setParameter('search_engine', $value);
+}
+
+if ($value = getenv('SOLR_DSN')) {
+    $container->setParameter('solr_dsn', $value);
+}
+
+// Logging settings
+if ($value = getenv('LOG_TYPE')) {
+    $container->setParameter('log_type', $value);
+}
+
+if ($value = getenv('LOG_PATH')) {
+    $container->setParameter('log_path', $value);
+}

--- a/bin/vhost.sh
+++ b/bin/vhost.sh
@@ -82,8 +82,8 @@ Usage:
 Defaults values will be fetched from the environment variables $env_list, but might be overriden using the arguments listed below.
 
 Arguments:
-  --basedir=<path>                         : Root path to where the eZ installation is placed, used for <path>/web
   --template-file=<file.template>          : The file to use as template for the generated ouput file
+  [--basedir=<path>]                       : Root path to eZ installation, auto detected if command is run from root
   [--host-name=localhost]                  : Primary host name, default "localhost"
   [--host-alias=*.localhost]               : Space separated list of host aliases, default "*.localhost"
   [--ip=*|127.0.0.1]                       : IP address web server should accept traffic on.
@@ -108,13 +108,13 @@ function inject_environment_variables
 {
     local current_env_variable
     local option_value
-    local template_var
+    local env_var
     local i
 
     i=0;
-    for template_var in "${option_vars[@]}"; do
-        # Remove "%" from from template_vars....
-        current_env_variable=${template_var//%/}
+    for env_var in "${option_vars[@]}"; do
+        # Remove "%" from from env_var....
+        current_env_variable=${env_var//%/}
         # Get value of variable referenced to by $current_env_variable. If env variable do not exists, value is set to ""
         option_value=${!current_env_variable:-SomeDefault}
         if [ "$option_value" != "SomeDefault" ]; then
@@ -207,8 +207,12 @@ if [ ! -f "$template_file" ] ; then
 fi
 
 if [[ "${template_values[0]}" == "" ]] ; then
-    show_help "--basedir=<path>" true
-    exit 1
+    if [ -d web/ ] ; then
+        template_values[0]=`pwd`
+    else
+        show_help "--basedir=<path>" true
+        exit 1
+    fi
 fi
 
 ## Option specific logic
@@ -226,7 +230,33 @@ fi
 template=$(<$template_file)
 COUNTER=0
 while [  "${template_vars[$COUNTER]}" != "" ]; do
-    tmp=${template//${template_vars[$COUNTER]}/${template_values[$COUNTER]}}
+    current_var=${template_vars[$COUNTER]}
+    current_value=${template_values[$COUNTER]}
+
+    # Replace %VAR% with the actual value
+    tmp=${template//${current_var}/${current_value}}
+
+    # If variable has a value then do further replacment logic
+    if [ "$current_value" != "" ] ; then
+        # Remove "%" from VAR for further use
+        current_var=${current_var//%/}
+
+        # Remove "#if[VAR] " comments to conditionally uncomment lines
+        tmp=${tmp//"#if[${current_var}] "/""}
+
+        # Remove "#if[VAR=value] " comments to conditionally uncomment lines
+        tmp=${tmp//"#if[${current_var}=${current_value}] "/""}
+
+        # Remove "#if[VAR!=some-other-value] " comments to conditionally uncomment lines (only supports one occurrence)
+        regex="if\[${current_var}!=([^]]*)\] "
+        if [[ $tmp =~ $regex ]] ; then
+            if [ "${BASH_REMATCH[1]}" != $current_value ] ; then
+                tmp=${tmp//"#if[${current_var}!=${BASH_REMATCH[1]}] "/""}
+            fi
+        fi
+    fi
+
+    # Set result on template var
     template=$tmp
     let COUNTER=COUNTER+1
 done

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -36,35 +36,35 @@
     # Environment.
     # Possible values: "prod" and "dev" out-of-the-box, other values possible with proper configuration
     # Defaults to "prod" if omitted (uses SetEnvIf so value can be used in rewrite rules)
-    SetEnvIf Request_URI ".*" SYMFONY_ENV=%SYMFONY_ENV%
+    #if[SYMFONY_ENV] SetEnvIf Request_URI ".*" SYMFONY_ENV=%SYMFONY_ENV%
 
     # Optional: Whether to use custom ClassLoader (autoloader) file
     # Needs to be a valid path relative to root web/ directory
     # Defaults to bootstrap.php.cache, or autoload.php in debug if env value is omitted or empty
-    SetEnv SYMFONY_CLASSLOADER_FILE "%SYMFONY_CLASSLOADER_FILE%"
+    #if[SYMFONY_CLASSLOADER_FILE] SetEnv SYMFONY_CLASSLOADER_FILE "%SYMFONY_CLASSLOADER_FILE%"
 
     # Optional: Whether to use debugging.
     # Possible values: 0, 1 or ""
     # Defaults to enabled if SYMFONY_ENV is set to "dev" if env value is omitted or empty
-    SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"
+    #if[SYMFONY_DEBUG] SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"
 
     # Optional: Whether to use Symfony's HTTP Caching.
     # Disable it if you are using an external reverse proxy (e.g. Varnish)
     # Possible values: 0, 1 or ""
     # Defaults to disabled if SYMFONY_ENV is set to "dev" or SYMFONY_TRUSTED_PROXIES is set,
     # and if this env value is omitted or empty
-    SetEnv SYMFONY_HTTP_CACHE "%SYMFONY_HTTP_CACHE%"
+    #if[SYMFONY_HTTP_CACHE] SetEnv SYMFONY_HTTP_CACHE "%SYMFONY_HTTP_CACHE%"
 
     # Optional: Whether to use custom HTTP Cache class if SYMFONY_HTTP_CACHE is enabled
     # Value must be a autoloadable cache class
     # Defaults to to use provided "AppCache" if env value is omitted or empty
-    SetEnv SYMFONY_HTTP_CACHE_CLASS "%SYMFONY_HTTP_CACHE_CLASS%"
+    #if[SYMFONY_HTTP_CACHE_CLASS] SetEnv SYMFONY_HTTP_CACHE_CLASS "%SYMFONY_HTTP_CACHE_CLASS%"
 
     # Optional: Defines the proxies to trust
     # Needed when using Varnish as proxy, if so disable SYMFONY_HTTP_CACHE.
     # Separate entries by a comma, example: "proxy1.example.com,proxy2.example.org"
     # Defaults to not be set if env value is omitted or empty
-    SetEnv SYMFONY_TRUSTED_PROXIES "%SYMFONY_TRUSTED_PROXIES%"
+    #if[SYMFONY_TRUSTED_PROXIES] SetEnv SYMFONY_TRUSTED_PROXIES "%SYMFONY_TRUSTED_PROXIES%"
 
     <IfModule mod_rewrite.c>
         RewriteEngine On

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -9,7 +9,7 @@ server {
     # Additional Assetic rules for eZ Publish 5.1 / 2013.4 and higher.
     ## Don't forget to run php app/console assetic:dump --env=prod
     ## and make sure to comment these out in DEV environment.
-    include ez_params.d/ez_prod_rewrite_params;
+    #if[SYMFONY_ENV!=dev] include ez_params.d/ez_prod_rewrite_params;
 
     # Cluster/streamed files rewrite rules. Enable on cluster with DFS as a binary data handler
     #rewrite "^/var/([^/]+/)?storage/images(-versioned)?/(.*)" "/app.php" break;
@@ -37,34 +37,34 @@ server {
             # Possible values: "prod" and "dev" out-of-the-box, other values possible with proper configuration
             # Make sure to comment the "ez_params.d/ez_prod_rewrite_params" include above in dev.
             # Defaults to "prod" if omitted
-            fastcgi_param SYMFONY_ENV %SYMFONY_ENV%;
+            #if[SYMFONY_ENV] fastcgi_param SYMFONY_ENV %SYMFONY_ENV%;
 
             # Whether to use custom ClassLoader (autoloader) file
             # Needs to be a valid path relative to root web/ directory
             # Defaults to bootstrap.php.cache, or autoload.php in debug
-            fastcgi_param SYMFONY_CLASSLOADER_FILE "%SYMFONY_CLASSLOADER_FILE%";
+            #if[SYMFONY_CLASSLOADER_FILE] fastcgi_param SYMFONY_CLASSLOADER_FILE "%SYMFONY_CLASSLOADER_FILE%";
 
             # Whether to use debugging.
             # Possible values: 0 or 1
             # Defaults to 0 if omitted, unless SYMFONY_ENV is set to: "dev"
-            fastcgi_param SYMFONY_DEBUG "%SYMFONY_DEBUG%";
+            #if[SYMFONY_DEBUG] fastcgi_param SYMFONY_DEBUG "%SYMFONY_DEBUG%";
 
             # Whether to use Symfony's HTTP Caching.
             # Disable it if you are using an external reverse proxy (e.g. Varnish)
             # Possible values: 0 or 1
             # Defaults to 1 if omitted, unless SYMFONY_ENV is set to: "dev"
-            fastcgi_param SYMFONY_HTTP_CACHE "%SYMFONY_HTTP_CACHE%";
+            #if[SYMFONY_HTTP_CACHE] fastcgi_param SYMFONY_HTTP_CACHE "%SYMFONY_HTTP_CACHE%";
 
             # Whether to use custom HTTP Cache class if SYMFONY_HTTP_CACHE is enabled
             # Value must be na autoloadable cache class
             # Defaults to "AppCache"
-            fastcgi_param SYMFONY_HTTP_CACHE_CLASS "%SYMFONY_HTTP_CACHE_CLASS%";
+            #if[SYMFONY_HTTP_CACHE_CLASS] fastcgi_param SYMFONY_HTTP_CACHE_CLASS "%SYMFONY_HTTP_CACHE_CLASS%";
 
             # Defines the proxies to trust.
             # Separate entries by a comma
             # Example: "proxy1.example.com,proxy2.example.org"
             # By default, no trusted proxies are set
-            fastcgi_param SYMFONY_TRUSTED_PROXIES "%SYMFONY_TRUSTED_PROXIES%";
+            #if[SYMFONY_TRUSTED_PROXIES] fastcgi_param SYMFONY_TRUSTED_PROXIES "%SYMFONY_TRUSTED_PROXIES%";
         }
     }
 


### PR DESCRIPTION
- Adds a `env.php` file to be able to inject parameters from env variables *(opt in, so can't use `SYMFONY__` here as it only works if param is not defined in yml)*
- Adjust `vhost.sh` and `vhost.templat`s to allow skipping undefined env vars *(so a php-fpm container can have them set on container instead of hardcoded in vhost of the httpd contianer, which is inconvinent for restarts of php to change settings)*

These are splitted out from #97 as it will need further work before it is ready.