### PR TITLE
[Behat] Add EzBehatExtension in behat.yml.dist

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -23,6 +23,8 @@ default:
             filename: report.xml
             outputDir: %paths.base%/app/logs/junit
 
+        EzSystems\PlatformBehatBundle\ServiceContainer\EzBehatExtension: ~
+
     # default profile: no suites
     suites: ~
 


### PR DESCRIPTION
Add to behat.yml.dist the [EzBehatExtension](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/PlatformBehatBundle/ServiceContainer/EzBehatExtension.php) which enables the usage of the [ArgumentResolver](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/PlatformBehatBundle/Context/Argument/AnnotationArgumentResolver.php) so that we can inject services in Behats contexts see [Accessing eZplatform Kernel Services](https://github.com/ezsystems/ezpublish-kernel/tree/master/doc/behat#accessing-ez-platform--kernel-services)