### PR TITLE
[Composer] Bump Symfony to 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "~5.5|~7.0",
-        "symfony/symfony": "~2.7.0",
+        "symfony/symfony": "~2.8.0",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25098

This will trigger a whole bunch of deprecation warnings for things removed in 3.0,
and if possible we will aim to take that gradually as soon as we merge this.

See: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md