### PR TITLE
EZP-25943: [Docker] Add redis config and way to inject it

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,4 @@ PHP_IMAGE=ezsystems/php:7.0-v0
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=mariadb:10.0
 SELENIUM_IMAGE=selenium/standalone-firefox
+REDIS_IMAGE=redis

--- a/app/config/cache_pool/singlememcached.yml
+++ b/app/config/cache_pool/singlememcached.yml
@@ -1,0 +1,7 @@
+# This custom cache pool "singlememcached" is loaded by env.php on demand
+stash:
+    caches:
+        singlememcached:
+            drivers: [Memcache]
+            Memcache:
+                servers: [ {server: '%cache_host%', port: 11211} ]

--- a/app/config/cache_pool/singleredis.yml
+++ b/app/config/cache_pool/singleredis.yml
@@ -1,0 +1,7 @@
+# This custom cache pool "singleredis" is loaded by env.php on demand
+stash:
+    caches:
+        singleredis:
+            drivers: [Redis]
+            Redis:
+                servers: [ {server: '%cache_host%', port: 6379} ]

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -6,3 +6,8 @@ parameters:
 
     # Log path, where to store the log files. php://stderr may be used in order to log to standard error
     log_path: "%kernel.logs_dir%/%kernel.environment%.log"
+
+    # Settings for Cache pool, to create your own pool see cache/ folder.
+    cache_pool: "default"
+
+    cache_host: 127.0.0.1

--- a/app/config/env.php
+++ b/app/config/env.php
@@ -2,6 +2,9 @@
 // On Symfony container compilation*, reads parameters from env variables if defined and overrides the yml parameters.
 // * For typical use cases like Docker, make sure to recompile Symfony container on run to refresh settings.
 
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader;
+
 if ($value = getenv('SYMFONY_SECRET')) {
     $container->setParameter('secret', $value);
 }
@@ -64,4 +67,18 @@ if ($value = getenv('LOG_TYPE')) {
 
 if ($value = getenv('LOG_PATH')) {
     $container->setParameter('log_path', $value);
+}
+
+// Cache settings
+// Config validation by Stash prohbitis us from pre defining pools using drivers not supported by all systems
+// So we expose a env variable to load and use other pools when needed, additional pools can be added in cache_pool/ folder.
+if ($pool = getenv('CUSTOM_CACHE_POOL')) {
+    $container->setParameter('cache_pool', $pool);
+
+    if ($host = getenv('CACHE_HOST')) {
+        $container->setParameter('cache_host', $host);
+    }
+
+    $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/cache_pool'));
+    $loader->load($pool . '.yml');
 }

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -19,6 +19,8 @@ ezpublish:
     # System settings, grouped by siteaccess and/or siteaccess group
     system:
         site_group:
+            # Pool to use for cache, needs to be differant per repository (database).
+            cache_pool_name: '%cache_pool%'
             # These reflect the current installers, complete installation before you change them. For changing var_dir
             # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
             # need to manually modify your database data to reflect this to avoid exceptions.

--- a/doc/docker-compose/redis.yml
+++ b/doc/docker-compose/redis.yml
@@ -1,0 +1,13 @@
+version: '2'
+# Redis config, to be appended to prod, prod+dev, ..., but before selenium.yml
+
+services:
+  app:
+    depends_on:
+     - redis
+    environment:
+     - CUSTOM_CACHE_POOL=singleredis
+     - CACHE_HOST=redis
+
+  redis:
+    image: ${REDIS_IMAGE}


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-25943

As a step towards cluster setup, adding redis so we can test that.
Memcached can easily be added as well later when it arrives with PHP 7.0 support, assuming we bother *(Symfony 3.x only support Redis, and adding extensions to php image increases it's size)*.