### PR TITLE
EZP - 26043 - PHP Garbage Collector symfony configuration logs out user of Platform UI

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -71,6 +71,7 @@ framework:
     trusted_hosts:   ~
     trusted_proxies: ~
     session:
+        gc_probability: 0
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~
         # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by


### PR DESCRIPTION
#### EZP - 26043 - PHP Garbage Collector symfony configuration logs out user of Platform UI

Due to the fact that Symfony configuration has the gc_probability: 1 by default, instead of using the php.ini one of '0'.
This means that there is a 1% chance that the GC process will start on each request. 
Since Platform UI make hundreds of requests the 1% probability will occur very fast.
