### PR TITLE
EZP-26500: fix some typo of nginx rewrite rules

### DIFF
--- a/doc/nginx/ez_params.d/ez_prod_rewrite_params
+++ b/doc/nginx/ez_params.d/ez_prod_rewrite_params
@@ -4,8 +4,8 @@
 ## and make sure to comment these out in DEV environment.
 rewrite "^/css/(.*)\.css" "/css/$1.css" break;
 rewrite "^/js/(.*)\.js" "/js/$1.js" break;
-rewrite "^/fonts?/(.*)\.ttf" "/font$1/$2.ttf" break;
-rewrite "^/fonts?/(.*)\.woff" "/font$1/$2.woff" break;
-rewrite "^/fonts?/(.*)\.otf" "/font$1/$2.otf" break;
-rewrite "^/fonts?/(.*)\.eot" "/font$1/$2.eot" break;
-rewrite "^/fonts?/(.*)\.svg" "/font$1/$2.svg" break;
+rewrite "^/font(s?)/(.*)\.ttf" "/font$1/$2.ttf" break;
+rewrite "^/font(s?)/(.*)\.woff" "/font$1/$2.woff" break;
+rewrite "^/font(s?)/(.*)\.otf" "/font$1/$2.otf" break;
+rewrite "^/font(s?)/(.*)\.eot" "/font$1/$2.eot" break;
+rewrite "^/font(s?)/(.*)\.svg" "/font$1/$2.svg" break;


### PR DESCRIPTION
fix some typo of nginx rewrite rules

rewrite "^/fonts?/(.*)\.ttf" "/font$1/$2.ttf" break; to rewrite "^/font(s?)/(.*)\.ttf" "/font$1/$2.ttf" break;