### PR TITLE
EZP-24854 EZP-26087 Update varnish configuration to purge required lo…

### DIFF
--- a/doc/varnish/vcl/varnish3.vcl
+++ b/doc/varnish/vcl/varnish3.vcl
@@ -116,7 +116,7 @@ sub ez_purge {
         }
 
         if (req.http.X-Location-Id) {
-            ban( "obj.http.X-Location-Id ~ " + req.http.X-Location-Id);
+            ban( "obj.http.X-Location-Id ~ \b" + req.http.X-Location-Id + "\b");
             if (client.ip ~ debuggers) {
                 set req.http.X-Debug = "Ban done for content connected to LocationId " + req.http.X-Location-Id;
             }

--- a/doc/varnish/vcl/varnish4.vcl
+++ b/doc/varnish/vcl/varnish4.vcl
@@ -113,7 +113,7 @@ sub ez_purge {
         }
 
         if (req.http.X-Location-Id) {
-            ban("obj.http.X-Location-Id ~ " + req.http.X-Location-Id);
+            ban("obj.http.X-Location-Id ~ \b" + req.http.X-Location-Id + "\b");
             if (client.ip ~ debuggers) {
                 set req.http.X-Debug = "Ban done for content connected to LocationId " + req.http.X-Location-Id;
             }


### PR DESCRIPTION
…cations only

cf https://jira.ez.no/browse/EZP-26087

The current implementation of varnish ban allows only one Location ID to be set in the X-Location-Id Header.

The proposal is to:

1. update default varnish configuration (this PR)
2. revert https://github.com/ezsystems/ezpublish-kernel/commit/12353b48909873ca5d71d6c11f7a896c70f3efda