### PR TITLE
EZP-26128: As a Developer I want deprecation issues resolved, so that application logs are clean

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -56,12 +56,14 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
-    form:            ~
     csrf_protection:
         enabled: true
-        # Note: changing this will break legacy extensions that rely on the default name to alter AJAX requests
-        # See https://jira.ez.no/browse/EZP-20783
-        field_name: ezxform_token
+    form:
+        csrf_protection:
+            enabled: true
+            # Note: changing this will break legacy extensions that rely on the default name to alter AJAX requests
+            # See https://jira.ez.no/browse/EZP-20783
+            field_name: ezxform_token
     validation:      { enable_annotations: true }
     # Place "eztpl" engine first intentionnally.
     # This is to avoid template name parsing with Twig engine, refusing specific characters

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -56,8 +56,6 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
-    csrf_protection:
-        enabled: true
     form:
         csrf_protection:
             enabled: true


### PR DESCRIPTION
JIRA Story: [EZP-26128](https://jira.ez.no/browse/EZP-26128)

This PR removes deprecated code from *ezplatform*. Right now it's only a small change to `config.yml`.

**TODO**:
- [x] Replace [deprecated `framework.csrf_protection.field_name`](https://github.com/symfony/symfony/commit/d79d2cf185d7b21b02d0abdb61bedfb52b2397a6) with `framework.form.csrf_protection.field_name`