### PR TITLE
EZP-26128: Align eZ Platform with Sensio Distribution Bundle v5.0

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -6,10 +6,6 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
-_configurator:
-    resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
-    prefix:   /_configurator
-
 # Symfony 2.6
 _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -7,7 +7,9 @@
          colors="true"
          bootstrap="autoload.php"
 >
-
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>../src/*/*Bundle/Tests</directory>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="bootstrap.php.cache"
+         bootstrap="autoload.php"
 >
 
     <testsuites>

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,7 +1,7 @@
 # This file contains the default configuration for behat testing using EzSystems/BehatBundle
 default:
     calls:
-        error_reporting: 14335 # E_ALL & ~E_USER_DEPRECATED
+        error_reporting: -1 # Report all PHP errors
     extensions:
         Behat\MinkExtension:
             base_url: 'http://localhost'

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
-        "sensio/distribution-bundle": "~3.0",
+        "sensio/distribution-bundle": "^5.0",
         "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "~0.4",

--- a/web/app.php
+++ b/web/app.php
@@ -18,10 +18,11 @@ if (($useDebugging = getenv('SYMFONY_DEBUG')) === false || $useDebugging === '')
 // Depending on SYMFONY_CLASSLOADER_FILE use custom class loader, otherwise use bootstrap cache, or autoload in debug
 if ($loaderFile = getenv('SYMFONY_CLASSLOADER_FILE')) {
     require_once $loaderFile;
-} elseif ($useDebugging) {
-    require_once __DIR__ . '/../app/autoload.php';
 } else {
-    require_once __DIR__ . '/../app/bootstrap.php.cache';
+    require_once __DIR__ . '/../app/autoload.php';
+    if (!$useDebugging) {
+        require_once __DIR__ . '/../app/bootstrap.php.cache';
+    }
 }
 
 require_once __DIR__ . '/../app/AppKernel.php';


### PR DESCRIPTION
PR related to the JIRA Story: [EZP-26128](https://jira.ez.no/browse/EZP-26128) and [Kernel PR #1750](https://github.com/ezsystems/ezpublish-kernel/pull/1750).

This PR bumps `sensio/distribution-bundle` to `v5.0` and updates `eZ Platform` according to [this update notes](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/UPGRADE.md).


Please note that:
- We still use `app/cache` and `app/logs` directories, so no changes to `app/AppKernel.php` are needed.
- `app_dev.php` includes `app.php`, so only `app.php` includes now autoloading code.
- `app/console` already includes autoloading code, so no change needed there.


**TODO**:
- [x] Bump `sensio/distribution-bundle` to `^5.0` (32c68bd).
- [x] Remove `_configurator` routing entry from `app/config/routing_dev.yml` (fc7620b).
- [x] Add autoloading code in front controllers (dc02e3d).
- [x] Ensure tests are run with full error reporting (0092f1b, 50a60fb).