### PR TITLE
Allow sensio/distribution-bundle 3.x, 4.x or 5.x to allow legacy bridge install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
-        "sensio/distribution-bundle": "^5.0",
+        "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0",
         "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "~0.4",


### PR DESCRIPTION
Followup to : https://github.com/ezsystems/ezplatform/commit/dfe122b1f386e5d9b70dc6b475038ab0c16a2231#commitcomment-18733964

Legacy bridge requires `sensio/distribution-bundle` 3.x or 4.x and will not be able to install with `^5.0` as a version requirement.