### PR TITLE
Docker improvments 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,57 +1,59 @@
 ### IDE files
-/.idea/
+.idea/
 
 ### GIT files
-/.git/
+.git
+vendor/*/*/.git
 
 ### Symfony template
 # Cache and logs (Symfony2)
-/app/cache/*
-/app/logs/*
-!app/cache/.gitkeep
-!app/logs/.gitkeep
+app/cache/*
+app/logs/*
+!app/cache/.keep
+!app/logs/.keep
 
 # Email spool folder
-/app/spool/*
+app/spool/*
 
 # Cache, session files and logs (Symfony3)
-/var/cache/*
-/var/logs/*
-/var/sessions/*
+var/cache/*
+var/logs/*
+var/sessions/*
 !var/cache/.gitkeep
 !var/logs/.gitkeep
 !var/sessions/.gitkeep
 
 # Parameters (should be regenerated in contianer)
-/app/config/parameters.yml
-/app/config/parameters.ini
+app/config/parameters.yml
 
 # Managed by Composer
-/app/bootstrap.php.cache
-/var/bootstrap.php.cache
-/bin/*
-!bin/console
-!bin/symfony_requirements
+app/bootstrap.php.cache
+var/bootstrap.php.cache
+#bin/*
+#!bin/console
+#!bin/symfony_requirements
 
 # Disabled as this is needed for dev setups unless we change dev to execute composer install automatically
-#/vendor/
+#vendor/
 
 # Assets and user uploads
-/web/bundles/
-/web/uploads/
+web/bundles/
+web/css/
+web/js/
+web/uploads/
 
 # Assets managed by Bower
-/web/assets/vendor/
+web/assets/vendor/
 
 # PHPUnit
-/app/phpunit.xml
-/phpunit.xml
+app/phpunit.xml
+phpunit.xml
 
 # Build data
-/build/
+build/
 
 # Composer PHAR
-/composer.phar
+composer.phar
 
 # Backup entities generated with doctrine:generate:entities command
 */Entity/*~

--- a/.env
+++ b/.env
@@ -21,6 +21,7 @@ REDIS_IMAGE=redis
 
 # App image name for use if you inted to push it to docker registry/hub.
 APP_PROD_IMAGE=my-ez-app
+APP_DOCKER_FILE=Dockerfile
 
 # Install config
 INSTALL_EZ_INSTALL_TYPE=clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ ENV SYMFONY_ENV=prod
 # Copy in project files into work dir
 COPY . /var/www
 
-# Remove cache folders to avoid layer issues, ref: https://github.com/docker/docker/issues/783
-RUN rm -Rf app/logs/* app/cache/* .git/* \
-    && mkdir -p web/var \
+# Check for ignored folders to avoid layer issues, ref: https://github.com/docker/docker/issues/783
+RUN if [ -d .git ]; then echo "ERROR: .dockerignore folders detected, exiting" && exit 1; fi
+
+# Install and prepare install
+RUN mkdir -p web/var \
     && composer install --optimize-autoloader --no-progress --no-interaction --prefer-dist \
 # Clear cache again so env variables are taken into account on startup
     && rm -Rf app/logs/* app/cache/*/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,17 @@ COPY . /var/www
 
 # Remove cache folders to avoid layer issues, ref: https://github.com/docker/docker/issues/783
 RUN rm -Rf app/logs/* app/cache/* .git/* \
- && mkdir -p web/var \
- && composer install --optimize-autoloader --no-progress --no-interaction --prefer-dist \
+    && mkdir -p web/var \
+    && composer install --optimize-autoloader --no-progress --no-interaction --prefer-dist \
 # Clear cache again so env variables are taken into account on startup
- && rm -Rf app/logs/* app/cache/*/* \
+    && rm -Rf app/logs/* app/cache/*/* \
 # Fix permissions for www-data
- && chown -R www-data:www-data app/cache app/logs web/var \
- && find app/cache app/logs web/var -type d | xargs chmod -R 775 \
- && find app/cache app/logs web/var -type f | xargs chmod -R 664 \
- && [ "$REMOVE_AUTH" = "1" ] && rm -f auth.json
+    && chown -R www-data:www-data app/cache app/logs web/var \
+    && find app/cache app/logs web/var -type d | xargs chmod -R 775 \
+    && find app/cache app/logs web/var -type f | xargs chmod -R 664 \
+# Remove composer cache to avoid it taking space in image
+    && rm -rf ~/.composer/*/* \
+    && [ "$REMOVE_AUTH" = "1" ] && rm -f auth.json
 
 # Declare volumes so it an can be shared with other containers
 # Also since run.sh will use setfacl, and that does not work on aufs (but volumes does not use that)

--- a/doc/docker-compose/base-prod.yml
+++ b/doc/docker-compose/base-prod.yml
@@ -3,7 +3,9 @@ version: '2'
 
 services:
   app:
-    build: ../../
+    build:
+      context: ../../
+      dockerfile: ${APP_DOCKER_FILE}
     image: ${APP_PROD_IMAGE}
     depends_on:
      - db


### PR DESCRIPTION
- Reduces image size down to php image +200mb as opposed to +300mb or more
- As .dockerimage is fixed as part of this, layering issues on cache/logs folders might now be completely fixed

Also added check in Dockerfile to verify ignored folders like `.git` is correctly removed as safety measure.

@bdunogier This might be a good time for you to retry on the setup where it did not work last time.