### PR TITLE
[Docker] Switch to slightly updated format for php image with entrypoint

### DIFF
--- a/.env
+++ b/.env
@@ -12,8 +12,8 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.0-v0
-PHP_IMAGE_DEV=ezsystems/php:7.0-v0-dev
+PHP_IMAGE=ezsystems/php:7.0-v1
+PHP_IMAGE_DEV=ezsystems/php:7.0-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=mariadb:10.0
 SELENIUM_IMAGE=selenium/standalone-firefox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ezsystems/php:7.0-v0
-
-MAINTAINER eZ Systems AS "engineering@ez.no"
+FROM ezsystems/php:7.0-v1
 
 # Build argument about keeping auth.json or not (by default on as prod images should'nt get updates via composer update)
 ARG REMOVE_AUTH=1
@@ -28,9 +26,4 @@ RUN mkdir -p web/var \
     && [ "$REMOVE_AUTH" = "1" ] && rm -f auth.json
 
 # Declare volumes so it an can be shared with other containers
-# Also since run.sh will use setfacl, and that does not work on aufs (but volumes does not use that)
 VOLUME /var/www /var/www/web/var
-
-EXPOSE 9000
-
-CMD /scripts/run.sh

--- a/doc/docker-compose/selenium.yml
+++ b/doc/docker-compose/selenium.yml
@@ -17,5 +17,5 @@ services:
      - selenium
     environment:
      - EZP_TEST_REST_HOST=web
-    # TODO: move this logic to container or entrypoint script
-    command: /bin/sh -c "cp -f behat.yml.dist behat.yml; sed -i 's@localhost:4444@selenium:4444@' behat.yml; sed -i 's@localhost@web@' behat.yml; sed -i 's@ behat@ ${SYMFONY_ENV}@' behat.yml; /scripts/run.sh"
+     - BEHAT_SELENIUM_HOST=selenium
+     - BEHAT_WEB_HOST=web


### PR DESCRIPTION
Switch to new [v1 image](https://github.com/ezsystems/docker-php/pull/15) of docker-php which has [entrypoint](https://github.com/ezsystems/docker-php/blob/master/php/scripts/docker-entrypoint.sh#L50-L58) which makes it possible to run custom logic in it on startup without having to extend it. It also contains support for adapting adapting behat.yml so we don't need to hardcode that as container command here.