### PR TITLE
Pin selenium docker image version to 2.53.1

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ PHP_IMAGE=ezsystems/php:7.0-v1
 PHP_IMAGE_DEV=ezsystems/php:7.0-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=mariadb:10.0
-SELENIUM_IMAGE=selenium/standalone-firefox
+SELENIUM_IMAGE=selenium/standalone-firefox:2.53.1
 REDIS_IMAGE=redis
 
 # App image name for use if you intend to push it to docker registry/hub.


### PR DESCRIPTION
Selenium 3 causes issue with behat because it uses the new marionette/geckodriver(see https://github.com/mozilla/geckodriver) which are not yet fully implemented. For now the version should be pinned to the previous one