### PR TITLE
EZP-26682: Add Content on the Fly Bundle in clean install

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -46,6 +46,7 @@ class AppKernel extends Kernel
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
+            new EzSystems\EzContentOnTheFlyBundle\EzSystemsEzContentOnTheFlyBundle(),
             new Bazinga\Bundle\JsTranslationBundle\BazingaJsTranslationBundle(),
             new AppBundle\AppBundle(),
         );

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -26,3 +26,7 @@ _ezpublishPlatformUIRoutes:
 
 _ezplatformRepositoryFormsRoutes:
     resource: "@EzSystemsRepositoryFormsBundle/Resources/config/routing.yml"
+
+_contentOnTheFly:
+    resource: "@ContentOnTheFlyBundle/Resources/config/routing.yml"
+    prefix:   '%ezpublish_rest.path_prefix%'

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "doctrine/doctrine-bundle": "~1.3",
         "symfony/expression-language": "~2.4",
         "sensio/framework-extra-bundle": "~3.0",
+        "ezsystems/content-on-the-fly-prototype": "~0.1.6",
         "willdurand/js-translation-bundle": "^2.6"
     },
     "require-dev": {


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26682


To be able to more strongly advice people to use clean for install and upgrade* make sure it has same level of features, given the rewrite to integrate the feature is currently on hold.

This applies to ezstudio as well, and once this is merged it can be naturally merged down there.

*_Doc on Studio says people can use demo for upgrade but that causes issue whenever demo add new demo specific features and people merge that in on upgrade. Note: On studio templates and config for landing pages is missing, so this is most likely the root cause for people using demo on upgrade._