### PR TITLE
EZP-26704: JMS Translation Bundle integration

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -48,6 +48,7 @@ class AppKernel extends Kernel
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
             new EzSystems\EzContentOnTheFlyBundle\EzSystemsEzContentOnTheFlyBundle(),
             new Bazinga\Bundle\JsTranslationBundle\BazingaJsTranslationBundle(),
+            new JMS\TranslationBundle\JMSTranslationBundle(),
             new AppBundle\AppBundle(),
         );
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0",
         "tedivm/stash-bundle": "~0.4",
-        "ezsystems/ezpublish-kernel": "~6.5@dev",
+        "ezsystems/ezpublish-kernel": "~6.7@dev",
         "ezsystems/repository-forms": "^1.4",
         "ezsystems/ezplatform-solr-search-engine": "^1.1@dev",
         "ezsystems/platform-ui-bundle": "~1.5@dev",


### PR DESCRIPTION
> [EZP-26704](http://jira.ez.no/browse/EZP-26704)

Adds [`jms/translation-bundle`](http://jmsyst.com/bundles/JMSTranslationBundle/master/usage) to the requirements.

This package adds a "description" feature, allowing developers to document the original string next to the source code:

```twig
{{ "title.doctor"|trans|desc("David Tenant") }}
```

```php
/** @Desc David Tenant */
$translator->trans("title.doctor");
```

The text will be used as the source in the XLF file, while the key will be stored as `resname`.

### TODO
- [ ] Remove requirements commit before merging
