### PR TITLE
Fix EZP-26748: Wrong image URI when content name has extended UTF characters

### DIFF
--- a/app/console
+++ b/app/console
@@ -7,6 +7,9 @@
 
 set_time_limit(0);
 
+// Ensure UTF-8 is used in string operations
+setlocale(LC_CTYPE, 'C.UTF-8');
+
 // Use autoload over boostrap here so we don't need to keep the generated files in git
 require_once __DIR__ . '/autoload.php';
 require_once __DIR__ . '/AppKernel.php';

--- a/web/app.php
+++ b/web/app.php
@@ -3,6 +3,9 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
+// Ensure UTF-8 is used in string operations
+setlocale(LC_CTYPE, 'C.UTF-8');
+
 // Environment is taken from "SYMFONY_ENV" variable, if not set, defaults to "prod"
 $environment = getenv('SYMFONY_ENV');
 if ($environment === false) {


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26748
> Test in https://github.com/ezsystems/ezpublish-kernel-ee/pull/145
> Taken from https://github.com/ezsystems/ezpublish-platform/pull/20 where the tests don't run
> Status: Ready to merge

Fixes the problem by ensuring UTF-8 is used, though this probably isn't the ideal way to do it. Anyway, let's see how the full tests go.