### PR TITLE
EZP-22401: Added ezplatform-http-cache package to the requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "ezsystems/ezplatform-solr-search-engine": "^1.1@dev",
         "ezsystems/platform-ui-bundle": "1.8.*@dev",
         "ezsystems/ez-support-tools": "~0.1.0",
+        "ezsystems/ezplatform-http-cache": "^0.1@dev",
         "ezplatform-i18n/ezplatform-i18n-ach_ug": "^1.0@dev",
         "egulias/listeners-debug-command-bundle": "~1.9",
         "white-october/pagerfanta-bundle": "1.0.*",


### PR DESCRIPTION
> Part of [EZP-22401](https://jira.ez.no/browse/EZP-22401)

Adds the [ezsystems/ezplatform-http-cache](http://github.com/ezsystems/ezplatform-http-cache) package to the requirements.

The bundle is NOT enabled by default, meaning that the http cache feature is identical to what it was before. When enabled, it will automatically replace the kernel http cache features with its own, including multi-tagging.