### PR TITLE
EZP-27060: Add platform.sh config

### DIFF
--- a/.env
+++ b/.env
@@ -22,5 +22,5 @@ REDIS_IMAGE=redis
 APP_PROD_IMAGE=my-ez-app
 APP_DOCKER_FILE=Dockerfile
 
-# Install config
+# Install config, used by .platform.app.yaml among others
 INSTALL_EZ_INSTALL_TYPE=clean

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ composer.lock
 .settings/
 behat.yml
 .php_cs.cache
+auth.json

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -44,19 +44,15 @@ mounts:
 hooks:
     build: |
         set -e
-        if [ -z "$SYMFONY_ENV" ]; then
-            export SYMFONY_ENV=prod
-        fi
         composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         rm web/app_dev.php
+        . ./.env
         app/console --env=$SYMFONY_ENV assetic:dump
     deploy: |
         set -e
-        if [ -z "$SYMFONY_ENV" ]; then
-            export SYMFONY_ENV=prod
-        fi
+        . ./.env
         if [ ! -f web/var/.platform.installed ]; then
-            php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV clean
+            php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV $INSTALL_EZ_INSTALL_TYPE
             touch web/var/.platform.installed
         fi
         app/console --env=$SYMFONY_ENV cache:clear

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,0 +1,77 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# Please see doc/platformsh/README.md and doc/platformsh/INSTALL.md
+# NB: Clustered eZ Platform setups are not tested and are likely to have issues.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php:7.0
+build:
+    # "none" means we're running composer manually, see build hook
+    flavor: "none"
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "mysqldb:mysql"
+    redis: "rediscache:redis"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/app.php"
+            # The number of seconds whitelisted (static) content should be cache
+            expires: 600
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "/app/cache": "shared:files/cache"
+    "/app/logs": "shared:files/logs"
+    "/web/var": "shared:files/files"
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    build: |
+        set -e
+        if [ -z "$SYMFONY_ENV" ]; then
+            export SYMFONY_ENV=prod
+        fi
+        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+        rm web/app_dev.php
+        app/console --env=$SYMFONY_ENV assetic:dump
+    deploy: |
+        set -e
+        if [ -z "$SYMFONY_ENV" ]; then
+            export SYMFONY_ENV=prod
+        fi
+        if [ ! -f web/var/.platform.installed ]; then
+            php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV demo
+            touch web/var/.platform.installed
+        fi
+        app/console --env=$SYMFONY_ENV cache:clear
+
+# The configuration of scheduled execution.
+# see http://symfony.com/doc/current/components/console/introduction.html
+#crons:
+#    symfony:
+#        spec: "*/20 * * * *"
+#        cmd: "php cron.php example:test"
+
+runtime:
+    extensions:
+        - xsl
+        - imagick
+        - redis
+        - readline

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,10 +47,16 @@ hooks:
         composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         rm web/app_dev.php
         . ./.env
+        if [ -z "$SYMFONY_ENV" ]; then
+            export SYMFONY_ENV=prod
+        fi
         app/console --env=$SYMFONY_ENV assetic:dump
     deploy: |
         set -e
         . ./.env
+        if [ -z "$SYMFONY_ENV" ]; then
+            export SYMFONY_ENV=prod
+        fi
         if [ ! -f web/var/.platform.installed ]; then
             php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV $INSTALL_EZ_INSTALL_TYPE
             touch web/var/.platform.installed

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -19,7 +19,6 @@ build:
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
     database: "mysqldb:mysql"
-    redis: "rediscache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -73,5 +72,4 @@ runtime:
     extensions:
         - xsl
         - imagick
-        - redis
         - readline

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -56,7 +56,7 @@ hooks:
             export SYMFONY_ENV=prod
         fi
         if [ ! -f web/var/.platform.installed ]; then
-            php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV demo
+            php -d memory_limit=-1 app/console ezplatform:install --env=$SYMFONY_ENV clean
             touch web/var/.platform.installed
         fi
         app/console --env=$SYMFONY_ENV cache:clear

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,0 +1,11 @@
+"http://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+        # As this does not support Vary, and purging, we can't use this as Sf Proxy drop in.
+        # However it is possible to enable this for anonymous traffic when backend sends expiry headers.
+        enabled: false
+
+"http://www.{default}/":
+    type: redirect
+    to: "http://{default}/"

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,4 +1,4 @@
-"http://{default}/":
+"https://{default}/":
     type: upstream
     upstream: "app:http"
     cache:
@@ -6,6 +6,6 @@
         # However it is possible to enable this for anonymous traffic when backend sends expiry headers.
         enabled: false
 
-"http://www.{default}/":
+"https://www.{default}/":
     type: redirect
-    to: "http://{default}/"
+    to: "https://{default}/"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,0 +1,6 @@
+mysqldb:
+    type: mysql:10.0
+    disk: 2048
+
+rediscache:
+    type: redis:3.0

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,6 +1,3 @@
 mysqldb:
     type: mysql:10.0
     disk: 2048
-
-rediscache:
-    type: redis:3.0

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
     - { resource: env/docker.php }
+    - { resource: env/platformsh.php }
 
 # Configuration for Database connection, can have several connections used by eZ Repositories in ezplatform.yml
 doctrine:

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -1,0 +1,38 @@
+<?php
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader;
+
+$relationships = getenv('PLATFORM_RELATIONSHIPS');
+if (!$relationships) {
+    return;
+}
+
+$relationships = json_decode(base64_decode($relationships), true);
+
+foreach ($relationships['database'] as $endpoint) {
+    if (empty($endpoint['query']['is_master'])) {
+        continue;
+    }
+
+    $container->setParameter('database_driver', 'pdo_' . $endpoint['scheme']);
+    $container->setParameter('database_host', $endpoint['host']);
+    $container->setParameter('database_port', $endpoint['port']);
+    $container->setParameter('database_name', $endpoint['path']);
+    $container->setParameter('database_user', $endpoint['username']);
+    $container->setParameter('database_password', $endpoint['password']);
+    $container->setParameter('database_path', '');
+}
+
+if (!empty($relationships['redis'][0])) {
+    // Configure redis cache pool to use for the install.
+    $container->setParameter('cache_pool', 'singleredis');
+    $container->setParameter('cache_host', $relationships['redis'][0]['host']);
+    $container->setParameter('cache_redis_port', $relationships['redis'][0]['port']);
+
+    $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../cache_pool'));
+    $loader->load('singleredis.yml');
+}
+
+# Store session into /tmp.
+ini_set('session.save_path', '/tmp/sessions');

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -1,8 +1,5 @@
 <?php
 
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader;
-
 $relationships = getenv('PLATFORM_RELATIONSHIPS');
 if (!$relationships) {
     return;
@@ -22,16 +19,6 @@ foreach ($relationships['database'] as $endpoint) {
     $container->setParameter('database_user', $endpoint['username']);
     $container->setParameter('database_password', $endpoint['password']);
     $container->setParameter('database_path', '');
-}
-
-if (!empty($relationships['redis'][0])) {
-    // Configure redis cache pool to use for the install.
-    $container->setParameter('cache_pool', 'singleredis');
-    $container->setParameter('cache_host', $relationships['redis'][0]['host']);
-    $container->setParameter('cache_redis_port', $relationships['redis'][0]['port']);
-
-    $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../cache_pool'));
-    $loader->load('singleredis.yml');
 }
 
 # Store session into /tmp.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -1,0 +1,47 @@
+# Install eZ Platform on Platform.sh
+
+> **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
+
+## Installation using eZ Platform template
+This is the simplest approach, but may be less up to date with current development than the other, more manual approach.
+
+1. Login or create an account at [Platform.sh](https://platform.sh)
+1. Create a Platform.sh project, using the "Create a blank site from a template" option. Select the "eZ Platform" stack template.
+1. Complete the setup wizard, and your eZ Platform site will be created.
+
+## Installation using an eZ Platform clone
+This requires more manual steps, but may be more up to date with current development than the template-based approach.
+
+**NB:** Some optional aspects of the installation require you to be project owner on a Platform.sh project. If you create a new project now, you will be.
+
+1. Login or create an account at [Platform.sh](https://platform.sh)
+1. Create a Platform.sh project, using the "Import your existing code" option. Follow the setup wizard, but halt at the end, before clicking "Finish".
+1. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) and clone your fork locally.
+1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:
+   `git remote add platform my_project@git.eu.platform.sh:my_project.git`
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
+      `export SYMFONY_ENV=dev`
+      If you don't do this, the local build will default to 'prod'.
+      **NB:** For this to affect remote builds, it must also be set as a Platform.sh project variable, see below.
+1. Push your branch. The Platform.sh setup wizard tells you the command to use. Example:
+   `git push -u platform master`
+   This starts the build process.
+   Now, finish the Platform.sh setup wizard.
+1. Optional: Install the Platform.sh CLI and set the env:symfony_env project variable
+   1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
+   1. Run `platform`
+      Run `platform get <your project id>`
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
+      `platform project:variable:set env:symfony_env prod`
+      If you don't do this, remote builds will default to 'prod'.
+      Then push an empty commit to trigger a Platform.sh rebuild:
+      `git commit --allow-empty -m'rebuild' && git push`
+      This will take a while, as it runs the full composer install.
+
+> **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.
+>
+> The symptom for this is when, in the backend, you go to Content -> Form Manager and get an error message, or when the "My Drafts Scheduled for Future Publication" and "All Drafts Scheduled for Future Publication" sections on "My Dashboard" will not load.
+>
+> To do this, go to the Platform.sh web interface -> "Access site" and copy the "SSH access" command. Then, run the SSH command from a terminal, and:
+> `rm web/var/.platform.installed`
+> The next time you trigger a rebuild (see above), the full install will run.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -17,27 +17,26 @@ This requires more manual steps, but may be more up to date with current develop
 1. Login or create an account at [Platform.sh](https://platform.sh)
 1. Create a Platform.sh project, using the "Import your existing code" option. Follow the setup wizard, but halt at the end, before clicking "Finish".
 1. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) and clone your fork locally.
-1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:
-   `git remote add platform my_project@git.eu.platform.sh:my_project.git`
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
-      `export SYMFONY_ENV=dev`
-      If you don't do this, the local build will default to 'prod'.
+1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
+   `git remote add platform my_project@git.eu.platform.sh:my_project.git`  
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
+      `export SYMFONY_ENV=dev`  
+      If you don't do this, the local build will default to 'prod'.  
       **NB:** For this to affect remote builds, it must also be set as a Platform.sh project variable, see below.
-1. Push your branch. The Platform.sh setup wizard tells you the command to use. Example:
-   `git push -u platform master`
-   This starts the build process.
-   Now, finish the Platform.sh setup wizard.
-   1. The build may fail due to mismatching SSH keys. If you are project administrator, verify that your Platform.sh project "Deploy key" (under "Configure project") is included among your GitHub SSH keys: https://github.com/settings/keys If not, copy the deploy key and add it on GitHub using the "New SSH key" button. Then push an empty commit to trigger a Platform.sh rebuild:
+1. Push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
+   `git push -u platform master`  
+   This starts the build process. Now, finish the Platform.sh setup wizard.
+   1. The build may fail due to mismatching SSH keys. If you are project administrator, verify that your Platform.sh project "Deploy key" (under "Configure project") is included among your GitHub SSH keys: https://github.com/settings/keys If not, copy the deploy key and add it on GitHub using the "New SSH key" button. Then push an empty commit to trigger a Platform.sh rebuild:  
       `git commit --allow-empty -m'rebuild' && git push`
 1. Optional: Install the Platform.sh CLI and set the env:symfony_env project variable
    1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
-   1. Run `platform`
+   1. Run `platform`  
       Run `platform get <your project id>`
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
-      `platform project:variable:set env:symfony_env prod`
-      If you don't do this, remote builds will default to 'prod'.
-      Then push an empty commit to trigger a Platform.sh rebuild:
-      `git commit --allow-empty -m'rebuild' && git push`
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
+      `platform project:variable:set env:symfony_env prod`  
+      If you don't do this, remote builds will default to 'prod'.  
+      Then push an empty commit to trigger a Platform.sh rebuild:  
+      `git commit --allow-empty -m'rebuild' && git push`  
       This will take a while, as it runs the full composer install.
 
 > **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -27,6 +27,8 @@ This requires more manual steps, but may be more up to date with current develop
    `git push -u platform master`
    This starts the build process.
    Now, finish the Platform.sh setup wizard.
+   1. The build may fail due to mismatching SSH keys. If you are project administrator, verify that your Platform.sh project "Deploy key" (under "Configure project") is included among your GitHub SSH keys: https://github.com/settings/keys If not, copy the deploy key and add it on GitHub using the "New SSH key" button. Then push an empty commit to trigger a Platform.sh rebuild:
+      `git commit --allow-empty -m'rebuild' && git push`
 1. Optional: Install the Platform.sh CLI and set the env:symfony_env project variable
    1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
    1. Run `platform`

--- a/doc/platformsh/README.md
+++ b/doc/platformsh/README.md
@@ -1,0 +1,19 @@
+# Use eZ Platform on Platform.sh
+
+> **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
+
+## What is Platform.sh?
+*Platform.sh* is a continuous deployment cloud hosting solution which can replicate a live production setup in seconds and create byte-level clones of throwaway dev and staging environments, which makes human testing and validation easy.
+
+## Current limitations
+- Clustering is not yet tested or supported.
+- Performance is limited, as installation instructions do not yet cover any particular CDN or HTTP caching tools like Varnish or Fastly.
+
+## Install
+For installation instructions, see [INSTALL.md](https://github.com/ezsystems/ezplatform/blob/master/doc/platformsh/INSTALL.md).
+
+## Platform.sh configuration files
+You may need to tweak these files after completing the installation.
+- [.platform.app.yaml](https://docs.platform.sh/configuration/app-containers.html) controls your application, including dependencies, build and deployment.
+- The `.platform` directory contains Platform.sh service and route settings.
+- `app/config/env/platformsh.php` ensures that database, cache, and sessions provided by or configured for Platform.sh is applied in eZ Platform. You should normally not need to change this, but there may be special cases where it is required.


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27060
> see also https://jira.ez.no/browse/EZS-1402
> Ready for review

Adds the necessary config files to run eZ Platform on platform.sh. This should also be added in the ezstudio and ezstudio-demo repos, see https://github.com/ezsystems/ezstudio/pull/43. Clustering not yet covered.

Note: The instructions in INSTALL.md are valid *after* this PR is merged. Before, in order to test it, you have to cherry pick the commits in this PR into the master branch of your fork, before attempting to make a platform.sh project out of it.

- [x] Add readme/installation doc in `doc/platformsh/`
- [x] ~~Switch to memcached once platform.sh has php-memcached 3.0.x available _(given it is what we officially recommend)_~~ Follow-up: https://jira.ez.no/browse/EZS-1413