### PR TITLE
EZP-27226: Move MultiFileUploadBundle above the PlatformUIBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,6 +36,7 @@ class AppKernel extends Kernel
             new eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle(),
             new eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle(),
             new eZ\Bundle\EzPublishIOBundle\EzPublishIOBundle(),
+            new EzSystems\MultiFileUploadBundle\EzSystemsMultiFileUploadBundle(),
             new eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle(),
             new EzSystems\PlatformUIAssetsBundle\EzSystemsPlatformUIAssetsBundle(),
             new EzSystems\PlatformUIBundle\EzSystemsPlatformUIBundle(),
@@ -49,7 +50,6 @@ class AppKernel extends Kernel
             new EzSystems\EzContentOnTheFlyBundle\EzSystemsEzContentOnTheFlyBundle(),
             new Bazinga\Bundle\JsTranslationBundle\BazingaJsTranslationBundle(),
             new JMS\TranslationBundle\JMSTranslationBundle(),
-            new EzSystems\MultiFileUploadBundle\EzSystemsMultiFileUploadBundle(),
             new AppBundle\AppBundle(),
         );
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-27226

This PR fixes the order of bundles inside the `AppKernel.php` file.
The `MultiFileUploadBundle` extends `PlatformUIBundle` hence it should be placed above the `PlatformUIBundle` in the `$bundles` array. This way we can avoid any unexpected issues with the `MultiFileUploadBundle`.