### PR TITLE
[Symfony 3] Fix missing csrf_protection setting

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -57,6 +57,7 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
+    csrf_protection: ~
     form:
         csrf_protection:
             enabled: true


### PR DESCRIPTION
In Symfony 2.8/3.x, `csrf_protection` is disabled globally by default.

In order to use CSRF, it's mandatory as of Symfony 3.0 to at least use default values
for `framework.csrf_protection` setting. Otherwise `security.csrf.token_manager` service
won't exist, leading to `ServiceNotFoundException` during container compilation.