### PR TITLE
[Symfony 3.3] Remove trusted_proxies config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -70,7 +70,6 @@ framework:
     templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     default_locale:  "%locale_fallback%"
     trusted_hosts:   ~
-    trusted_proxies: ~
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~


### PR DESCRIPTION
In Symony 3.3, `trusted_proxies` config has been removed and results in the following exception:

```
[InvalidArgumentException]                                                   
The "framework.trusted_proxies" configuration key has been removed in Symfony
3.3. Use the Request::setTrustedProxies() method in your front controller instead.
```