### PR TITLE
Let .gitignore behave like a whitelist for /bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@
 /bin/*
 !/bin/.ci/
 !/bin/.travis/
-!/bin/synchronize-translations/
-!/bin/vhost.sh/
+!/bin/synchronize-translations
+!/bin/vhost.sh
 /app/check.php
 /app/SymfonyRequirements.php
 /app/cache/

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@
 
 /vendor/
 .php~
-/bin/behat
-/bin/phpunit
+/bin/*
+!/bin/.ci/
+!/bin/.travis/
+!/bin/synchronize-translations/
+!/bin/vhost.sh/
 /app/check.php
 /app/SymfonyRequirements.php
 /app/cache/


### PR DESCRIPTION
When I freshly cloned this project and performed a composer install I already had changed files:
![bildschirmfoto 2017-06-06 um 18 09 34](https://user-images.githubusercontent.com/1222377/26839847-88efb672-4ae4-11e7-9af4-739d166402ad.png)

This pull request will avoid this situation. Especially for new users / new projects this is a benefit.

Sometimes third party composer packages will bring up new binaries that are stored beneath `/bin`. By ignoring all files - except the files that should be part of the project - newly added files are automatically ignored.

To add a file to the project that file needs to be added to the list. This way consumes less time in maintaining.

A better alternative would be to remove the composer option that will install the binaries to the `/bin` folder and use the `/vendor/bin` folder instead. But that might force a lot of other people to change their scripts. Therefore I think we can keep the binaries there.