### PR TITLE
Fix EZP-27285: Prevent access to website with direct usage of app.php in URL (404)

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -102,6 +102,10 @@
         RewriteCond %{ENV:SYMFONY_ENV} !^(dev)
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
+        # Prevent access to website with direct usage of app.php in URL
+        # More info here: https://jira.ez.no/browse/EZP-27285
+        RewriteRule ^/(.+/)?app\.php - [R=404,L]
+
         RewriteRule .* /app.php
     </IfModule>
 

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -103,7 +103,6 @@
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Prevent access to website with direct usage of app.php in URL
-        # More info here: https://jira.ez.no/browse/EZP-27285
         RewriteRule ^/(.+/)?app\.php - [R=404,L]
 
         RewriteRule .* /app.php

--- a/doc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/ez_params.d/ez_rewrite_params
@@ -18,7 +18,6 @@ rewrite "^/bundles/(.*)" "/bundles/$1" break;
 rewrite "^/assets/(.*)" "/assets/$1" break;
 
 # Prevent access to website with direct usage of app.php in URL
-# More info here: https://jira.ez.no/browse/EZP-27285
 if ($request_uri ~ "^/(.+/)?app\.php") {
     return 404;
 }

--- a/doc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/ez_params.d/ez_rewrite_params
@@ -17,5 +17,11 @@ rewrite "^/w3c/p3p\.xml" "/w3c/p3p.xml" break;
 rewrite "^/bundles/(.*)" "/bundles/$1" break;
 rewrite "^/assets/(.*)" "/assets/$1" break;
 
+# Prevent access to website with direct usage of app.php in URL
+# More info here: https://jira.ez.no/browse/EZP-27285
+if ($request_uri ~ "^/(.+/)?app\.php") {
+    return 404;
+}
+
 rewrite "^(.*)$" "/app.php$1" last;
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27285

# Description

The main propose of this PR is to open discussion about default configuration of URL Rewrite Engine which currently allows access to EZP based websites with direct usage of app.php in URL e.g. 

* http://exemple.com/app.php
* http://example.com/anything/you/want/app.php

Besides of non-loaded assets, it may impact on SEO because of [content duplication](https://support.google.com/webmasters/answer/66359?hl=en).

# TODO: 

- [X] Change vhost template for Apache
- [x] Change vhost template for Nginx  

# Update

This PR solves EZP-27286 issue with a 404 "Not found" response. Alternative solution with 301 redirect: https://github.com/ezsystems/ezplatform/pull/193