### PR TITLE
Fix-EZP-27724: Unable to run dockerized Solr

### DIFF
--- a/doc/docker-compose/Dockerfile-solr
+++ b/doc/docker-compose/Dockerfile-solr
@@ -1,4 +1,4 @@
-FROM solr:6-alpine
+FROM solr:6.5-alpine
 
 # Copy solr config from the version used by eZ Platform
 COPY vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/ /opt/solr/server/tmp


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27724](https://jira.ez.no/browse/EZP-27724)

# Description
As described in issue, run Solr is impossible because in the newest version of Solr ``6.6.0`` field ``defaultSearchField`` is deprecated. 
This PR changes dockerized version of Solr to ``6.5``. 