### PR TITLE
Backport some cleanups of config and autoload usage from v2

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,11 +51,11 @@ stash:
     tracking_values: false
 
 framework:
-    esi:             ~
-    translator:      { fallback: "%locale_fallback%" }
-    secret:          "%secret%"
+    esi: ~
+    translator: { fallback: '%locale_fallback%' }
+    secret: '%secret%'
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: '%kernel.root_dir%/config/routing.yml'
         strict_requirements: ~
     csrf_protection: ~
     form:
@@ -64,32 +64,36 @@ framework:
             # Note: changing this will break legacy extensions that rely on the default name to alter AJAX requests
             # See https://jira.ez.no/browse/EZP-20783
             field_name: ezxform_token
-    validation:      { enable_annotations: true }
-    # Place "eztpl" engine first intentionnally.
+    validation: { enable_annotations: true }
+    #serializer: { enable_annotations: true }
+    # Place "eztpl" engine first intentionally if you setup use with legacy bridge.
     # This is to avoid template name parsing with Twig engine, refusing specific characters
     # which are valid with legacy tpl files.
-    templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
-    default_locale:  "%locale_fallback%"
-    trusted_hosts:   ~
+    templating:
+        engines: ['twig']
+        #assets_version: SomeVersionScheme
+    default_locale: '%locale_fallback%'
+    trusted_hosts: ~
     session:
+        # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~
         # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by
         #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
-        #       Further reading on sessions: https://doc.ez.no/display/EZP/Session
-    fragments:       ~
+        #       Further reading on sessions: http://doc.ezplatform.com/en/master/guide/sessions/
+    fragments: ~
     http_method_override: true
 
 # Twig Configuration
 twig:
-    debug:            "%kernel.debug%"
-    strict_variables: "%kernel.debug%"
+    debug: '%kernel.debug%'
+    strict_variables: '%kernel.debug%'
 
 # Assetic Configuration
 assetic:
-    debug:          "%kernel.debug%"
-    use_controller: false
-    bundles:        []
+    debug: '%kernel.debug%'
+    use_controller: '%kernel.debug%'
+    bundles: []
     #java: /usr/bin/java
     filters:
         cssrewrite: ~
@@ -100,8 +104,8 @@ assetic:
 
 # Swiftmailer Configuration
 swiftmailer:
-    transport: "%mailer_transport%"
-    host:      "%mailer_host%"
-    username:  "%mailer_user%"
-    password:  "%mailer_password%"
-    spool:     { type: memory }
+    transport: '%mailer_transport%'
+    host: '%mailer_host%'
+    username: '%mailer_user%'
+    password:  '%mailer_password%'
+    spool: { type: memory }

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -4,7 +4,7 @@ imports:
 
 framework:
     router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
+        resource: '%kernel.root_dir%/config/routing_dev.yml'
         strict_requirements: true
     profiler: { only_exceptions: false }
 
@@ -15,18 +15,18 @@ web_profiler:
 monolog:
     handlers:
         main:
-            type:   "%log_type%"
-            path:   "%log_path%"
-            level:  debug
+            type: '%log_type%'
+            path: '%log_path%'
+            level: debug
         console:
-            type:   console
+            type: console
             bubble: false
             verbosity_levels:
                 VERBOSITY_VERBOSE: INFO
                 VERBOSITY_VERY_VERBOSE: DEBUG
             channels: ["!doctrine"]
         console_very_verbose:
-            type:   console
+            type: console
             bubble: false
             verbosity_levels:
                 VERBOSITY_VERBOSE: NOTICE

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -15,13 +15,13 @@ imports:
 monolog:
     handlers:
         main:
-            type:         fingers_crossed
-            # eZ Publish sets this to critical instead of error to avoid too verbose logs in prod
+            type: fingers_crossed
+            # eZ Platform sets this to critical instead of error to avoid too verbose logs in prod
             action_level: critical
-            handler:      nested
+            handler: nested
         nested:
-            type:  "%log_type%"
-            path:  "%log_path%"
+            type: '%log_type%'
+            path: '%log_path%'
             level: debug
         console:
-            type:  console
+            type: console

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -1,14 +1,14 @@
 ezpublish:
     # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'http' you can point it to Varnish
     http_cache:
-        purge_type: %purge_type%
+        purge_type: '%purge_type%'
 
     # Repositories configuration, setup default repository to support solr if enabled
     repositories:
         default:
             storage: ~
             search:
-                engine: "%search_engine%"
+                engine: '%search_engine%'
                 connection: default
 
     # Siteaccess configuration, with one siteaccess per default
@@ -35,4 +35,4 @@ ezpublish:
             languages: [eng-GB]
             # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
             http_cache:
-                purge_servers: ["%purge_server%"]
+                purge_servers: ['%purge_server%']

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,37 +1,39 @@
 login:
-    path:   /login
-    defaults:  { _controller: ezpublish.security.controller:loginAction }
+    path: /login
+    defaults: { _controller: ezpublish.security.controller:loginAction }
+
 login_check:
-    path:   /login_check
+    path: /login_check
+
 logout:
-    path:   /logout
+    path: /logout
 
 _ezpublishRoutes:
-    resource: "@EzPublishCoreBundle/Resources/config/routing/internal.yml"
+    resource: '@EzPublishCoreBundle/Resources/config/routing/internal.yml'
 
 _ezpublishRestRoutes:
-    resource: "@EzPublishRestBundle/Resources/config/routing.yml"
-    prefix:   "%ezpublish_rest.path_prefix%"
+    resource: '@EzPublishRestBundle/Resources/config/routing.yml'
+    prefix: '%ezpublish_rest.path_prefix%'
 
 _ezpublishRestOptionsRoutes:
-    resource: "@EzPublishRestBundle/Resources/config/routing.yml"
-    prefix: "%ezpublish_rest.path_prefix%"
+    resource: '@EzPublishRestBundle/Resources/config/routing.yml'
+    prefix: '%ezpublish_rest.path_prefix%'
     type: rest_options
 
 _liip_imagine:
-    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+    resource: '@LiipImagineBundle/Resources/config/routing.xml'
 
 _ezpublishPlatformUIRoutes:
-    resource: "@eZPlatformUIBundle/Resources/config/routing.yml"
+    resource: '@eZPlatformUIBundle/Resources/config/routing.yml'
 
 _ezplatformRepositoryFormsRoutes:
-    resource: "@EzSystemsRepositoryFormsBundle/Resources/config/routing.yml"
+    resource: '@EzSystemsRepositoryFormsBundle/Resources/config/routing.yml'
 
 _contentOnTheFly:
-    resource: "@ContentOnTheFlyBundle/Resources/config/routing.yml"
-    prefix:   "%ezpublish_rest.path_prefix%"
+    resource: '@ContentOnTheFlyBundle/Resources/config/routing.yml'
+    prefix: '%ezpublish_rest.path_prefix%'
 
 _multiFileUpload:
-    resource: "@EzSystemsMultiFileUploadBundle/Resources/config/routing.yml"
-    prefix:   "%ezpublish_rest.path_prefix%"
+    resource: '@EzSystemsMultiFileUploadBundle/Resources/config/routing.yml'
+    prefix: '%ezpublish_rest.path_prefix%'
 

--- a/app/config/routing_behat.yml
+++ b/app/config/routing_behat.yml
@@ -2,4 +2,4 @@ _main:
     resource: routing_dev.yml
 
 _ezplatform_behat:
-    resource: "@EzPlatformBehatBundle/Resources/config/routing.yml"
+    resource: '@EzPlatformBehatBundle/Resources/config/routing.yml'

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,15 +1,14 @@
 _wdt:
-    resource: "@WebProfilerBundle/Resources/config/routing/wdt.xml"
-    prefix:   /_wdt
+    resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+    prefix: /_wdt
 
 _profiler:
-    resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
-    prefix:   /_profiler
+    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+    prefix: /_profiler
 
-# Symfony 2.6
 _errors:
-    resource: "@TwigBundle/Resources/config/routing/errors.xml"
-    prefix:   /_error
+    resource: '@TwigBundle/Resources/config/routing/errors.xml'
+    prefix: /_error
 
 _main:
     resource: routing.yml

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,4 +1,7 @@
+# To get started with security, check out the documentation:
+# https://symfony.com/doc/current/security.html
 security:
+    # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         ezpublish:
             id: ezpublish.security.user_provider
@@ -6,6 +9,7 @@ security:
 #!            memory: ~
 
     firewalls:
+        # disables authentication for assets and the profiler, adapt it according to your needs
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,14 @@
         "ezsystems/ezpublish-community": "*"
     },
     "autoload": {
-        "psr-0": { "": "src/" }
+        "psr-4": {
+            "AppBundle\\": "src/AppBundle/"
+        },
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\": "tests/" },
+        "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
     },
     "require": {
         "php": "~5.6|~7.0",
@@ -58,7 +65,7 @@
         "ezsystems/legacy-bridge": "Provides the full legacy backoffice and legacy features"
     },
     "scripts": {
-        "build": [
+        "symfony-scripts": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
@@ -67,10 +74,10 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],
         "post-install-cmd": [
-            "@build"
+            "@symfony-scripts"
         ],
         "post-update-cmd": [
-            "@build"
+            "@symfony-scripts"
         ],
         "post-create-project-cmd": [
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"

--- a/web/app.php
+++ b/web/app.php
@@ -28,8 +28,6 @@ if ($loaderFile = getenv('SYMFONY_CLASSLOADER_FILE')) {
     }
 }
 
-require_once __DIR__ . '/../app/AppKernel.php';
-
 if ($useDebugging) {
     Debug::enable();
 }
@@ -54,7 +52,6 @@ if ($useHttpCache) {
     if ($httpCacheClass = getenv('SYMFONY_HTTP_CACHE_CLASS')) {
         $kernel = new $httpCacheClass($kernel);
     } else {
-        require_once __DIR__ . '/../app/AppCache.php';
         $kernel = new AppCache($kernel);
     }
 }


### PR DESCRIPTION
Changes _(from symfony standard)_:
- Don't align yml config entries
- Use ' over " around parameters in yml
- Use PSR-4 autoloading to get rid of blank load rule for possible src files causing file stat calls all the time unless class map is generated
- Added some more inline doc

Also from v2: updated some YML inline eZ Platform doc / links.

Note: Additional goal here is to reduce the 2.0 diff to simplify rebases when needed.