### PR TITLE
EZEE-1710 change selenium version

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ PHP_IMAGE=ezsystems/php:7.1-v1
 PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
-SELENIUM_IMAGE=selenium/standalone-firefox:2.53.1
+SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.4.0
 REDIS_IMAGE=healthcheck/redis
 
 # App image name for use if you intend to push it to docker registry/hub.

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,10 +6,16 @@ default:
         Behat\MinkExtension:
             base_url: 'http://localhost'
             goutte: ~
-            selenium2:
-                wd_host: 'http://localhost:4444/wd/hub'
             javascript_session: selenium2
-            browser_name: firefox
+            selenium2:
+                browser: chrome
+                wd_host: 'http://localhost:4444/wd/hub'
+                capabilities:
+                    extra_capabilities:
+                        chromeOptions:
+                            args:
+                                - "--window-size=1440,1080"
+                                - "--no-sandbox"
 
         Behat\Symfony2Extension:
             kernel:

--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -13,6 +13,8 @@ services:
      - SCREEN_DEPTH=24
     networks:
      - backend
+    # Because of: https://github.com/elgalu/docker-selenium/issues/20
+    shm_size: 1g 
 
   app:
     depends_on:


### PR DESCRIPTION
> JIRA: [EZEE-1710](https://jira.ez.no/browse/EZEE-1710)

# Description

The Firefox version used together with Selenium Server 2.53.1 is no longer able to login to Studio admin panel, so there is a need for upgrade to keep Behat tests running.

My solution is to change the Selenium version to 3.4.0 and the driver to Chrome.
My reasoning is as follows:
- there have been huge changes to Firefox driver between 2.* and 3.* (switching to Marionette etc.). Studio tests rely heavily on drag&drops, which started working only recently (in Selenium 3.5.\*, it failed in 3.4.\* in my experiments). Related Selenium issue: https://github.com/SeleniumHQ/selenium/issues/3693
- unfortunately Mink does not support Selenium 3.5.* yet - TraversableElement::findField method does not find elements (and there are many usages of this method in our code)
- With that in mind I've decided that for now it's best for us to switch the driver to Chrome - to keep environments identical, I suggest Selenium Server 3.4.0 (it's the latest official image available: https://hub.docker.com/r/selenium/standalone-chrome/tags/). It uses Chrome 59.0.3071.115, which has been released 26.06.2017.

I think it's best when the same driver is used cross the whole project (that's why this PR is to ezplatform and not ezplatform-ee). So far I've tested it locally and the tests look pretty stable to me.

Any suggestions are welcome.

I'm marking it as WIP until the Travis build passes.

