### PR TITLE
EZEE-1710: Check SHM sizes

### DIFF
--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -14,7 +14,7 @@ services:
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: 1g 
+    shm_size: 128m
 
   app:
     depends_on:


### PR DESCRIPTION
> JIRA: [EZEE-1710](https://jira.ez.no/browse/EZEE-1710)

# Description

I'm testing various SHM sizes to find the lowest one for which the tests are stable, as suggested by Vidar here: https://github.com/ezsystems/ezplatform/pull/203 

Result: 128m is fine for Platform - build was green 10 times in a row.