### PR TITLE
Enable roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/expression-language": "~2.4",
         "sensio/framework-extra-bundle": "~3.0",
         "ezsystems/content-on-the-fly-prototype": "~0.1.7",
-        "willdurand/js-translation-bundle": "^2.6"
+        "willdurand/js-translation-bundle": "^2.6",
+        "roave/security-advisories": "dev-master"
     },
     "require-dev": {
         "behat/behat": "~3.0",


### PR DESCRIPTION
> Ready for review

Purpose: Prevent accidental require/update to known vulnerabilities.
See https://github.com/Roave/SecurityAdvisories which also explains why `dev-master` is used.

Manual test that a vulnerable package is refused:
```
$ composer require zendframework/zendframework:2.3.1
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - zendframework/zendframework 2.3.1 conflicts with roave/security-advisories[dev-master].
```

Manual test that Symfony's security checker does its thing:
```
$ php bin/security-checker security:check composer.lock
Symfony Security Check Report
=============================
 // Checked file: /home/gl/git/ezplatform/composer.lock
 [OK] No packages have known vulnerabilities.
 ! [NOTE] This checker can only detect vulnerabilities that are referenced in the SensioLabs security advisories
 !        database. Execute this command regularly to check the newly discovered vulnerabilities.
```