### PR TITLE
[WIP] EZEE-1710: Check if shm size is too low for platform-ui non-edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - TEST_CMD="bin/behat -vv --profile=rest --suite=fullXml --tags=~@broken"
     - TEST_CMD="bin/behat -vv --profile=core --tags=~@broken"
     - TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
-    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+    - TEST_CMD="bin/behat -vv --no-interaction --profile=platformui --tags='~@edge'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
 
 # test only master (+ Pull requests)
 branches:

--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -14,7 +14,7 @@ services:
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: 256m
+    shm_size: 128m
 
   app:
     depends_on:

--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -14,7 +14,7 @@ services:
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: 128m
+    shm_size: 256m
 
   app:
     depends_on:


### PR DESCRIPTION
### Do not merge

I'm checking if the tests that are run in PlatformUI repository can be fixed with specifying greater shm-size in selenium docker container.

If this build fails (as this one: https://travis-ci.org/ezsystems/PlatformUIBundle/jobs/275153347) with:
```
When I create a content of this Type                                                             
# EzSystems\PlatformUIBundle\Features\Context\Fields::createAContentOfThisType()
      WebDriver\Exception\UnknownError: unknown error: session deleted because of page crash
```
I will create another commit increasing the shm-size. If it passes the test command change will be reverted.