### PR TITLE
EZP-27885: solr core name as parameter

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,7 +24,7 @@ ez_search_engine_solr:
     endpoints:
         endpoint0:
             dsn: "%solr_dsn%"
-            core: collection1
+            core: "%solr_core%"
     connections:
         default:
             entry_endpoints:

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -13,6 +13,7 @@ parameters:
 
     # Solr root endpoint, relevant if `solr` is set as search_engine
     solr_dsn: http://localhost:8983/solr
+    solr_core: collection1
 
     ## Logging settings
     # Log type is one of "stream", "error_log" or other types supported by monolog


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-27885

This PR adds a new entry in `default_parameters.yml` which replaces the hardcoded string `collection1` in `config.yml` in order to allow overriding this value for each instance.

original description:
>I always wondered why `solr_core`, unlike similar settings (`database_name`, `search_engine`, ...), is hardcoded in config.yml by default. 
>
> This simple change retains the default behavior but enables multiple instances of ezplatform on the same server, development machine, etc to use separate solr cores of the same solr endpoint.
>
> (I guess everyone who requires setups like these already changed their config.yml in a similar fashion)