### PR TITLE
EZEE-1710: Increase shm size to fix PlatformUI tests

### DIFF
--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -14,7 +14,7 @@ services:
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: 128m
+    shm_size: 256m
 
   app:
     depends_on:


### PR DESCRIPTION
Recently the build for PlatformUI have been failing, example failure can be seen [here](https://travis-ci.org/ezsystems/PlatformUIBundle/jobs/275153347):
```
When I create a content of this Type                                                             
# EzSystems\PlatformUIBundle\Features\Context\Fields::createAContentOfThisType()
      WebDriver\Exception\UnknownError: unknown error: session deleted because of page crash
```

I've set another branch in PlatformUI to use the increased shm size:
https://github.com/ezsystems/PlatformUIBundle/pull/901

The build for PlatformUI ~edge behat tests was green few times in a row.