### PR TITLE
[CS] Aligned php-cs-fixer config with changes introduced by v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,7 +12,12 @@ return PhpCsFixer\Config::create()
         'phpdoc_to_comment' => false,
         'cast_spaces' => false,
         'blank_line_after_opening_tag' => false,
+        'single_blank_line_before_namespace' => false,
+        'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
+        'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -6,7 +6,7 @@
 // Feel free to remove this, extend it, or make something more sophisticated at your own risk.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1']) || php_sapi_name() === 'cli-server')
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1']) || PHP_SAPI === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check ' . basename(__FILE__) . ' for more information.');


### PR DESCRIPTION
This PR introduces alignment of php-cs-fixer config after update to `v2.7.1`
Backported to: **1.7 LTS**

php-cs-fixer config was taken from ezsystems/ezpublish-kernel#2107

**TODO**:
- [x] Update php-cs-fixer configuration
- [x] Apply CS rule `function_to_constant`