### PR TITLE
EZP-28126: Change default Varnish VCL to not cache user varying content in proxies or browsers

### DIFF
--- a/doc/varnish/vcl/varnish4_xkey.vcl
+++ b/doc/varnish/vcl/varnish4_xkey.vcl
@@ -69,6 +69,9 @@ sub vcl_recv {
     // Retrieve client user context hash and add it to the forwarded request.
     call ez_user_context_hash;
 
+    // Sort the query string for cache normalization.
+    set req.url = std.querysort(req.url);
+
     // If it passes all these tests, do a lookup anyway.
     return (hash);
 }
@@ -205,14 +208,24 @@ sub vcl_deliver {
 
     // Remove the vary on user context hash, this is nothing public. Keep all
     // other vary headers.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Hash *", "");
-    set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
-    if (resp.http.Vary == "") {
-        unset resp.http.Vary;
-    }
+    if (resp.http.Vary ~ "X-User-Hash") {
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Hash *", "");
+        set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
+        if (resp.http.Vary == "") {
+            unset resp.http.Vary;
+        }
 
-    // Sanity check to prevent ever exposing the hash to a client.
-    unset resp.http.x-user-hash;
+        // If we vary by user hash, we'll also adjust the cache control headers going out by default to avoid sending
+        // large ttl meant for Varnish to shared proxies and such. We assume only session cookie is left after vcl_recv.
+        if (req.http.cookie) {
+            // When in session where we vary by user hash we by default avoid caching this in shared proxies & browsers
+            // For browser cache with it revalidating against varnish, use for instance "private, no-cache" instead
+            resp.http.cache-control = "private, no-cache, no-store, must-revalidate"
+        } else if (resp.http.cache-control ~ "public") {
+            // For non logged in users we allow caching to happen on shared proxies for a short while, as we cant purge
+            resp.http.cache-control = "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=300"
+        }
+    }
 
     if (client.ip ~ debuggers) {
         if (resp.http.X-Varnish ~ " ") {
@@ -223,5 +236,7 @@ sub vcl_deliver {
     } else {
         // Remove tag headers when delivering to non debug client
         unset resp.http.xkey;
+        // Sanity check to prevent ever exposing the hash to a non debug client.
+        unset resp.http.x-user-hash;
     }
 }

--- a/doc/varnish/vcl/varnish4_xkey.vcl
+++ b/doc/varnish/vcl/varnish4_xkey.vcl
@@ -65,7 +65,7 @@ sub vcl_recv {
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
         return (hash);
     }
-    
+
     // Sort the query string for cache normalization.
     set req.url = std.querysort(req.url);
 

--- a/doc/varnish/vcl/varnish4_xkey.vcl
+++ b/doc/varnish/vcl/varnish4_xkey.vcl
@@ -222,7 +222,8 @@ sub vcl_deliver {
             // For browser cache with it revalidating against varnish, use for instance "private, no-cache" instead
             resp.http.cache-control = "private, no-cache, no-store, must-revalidate"
         } else if (resp.http.cache-control ~ "public") {
-            // For non logged in users we allow caching to happen on shared proxies for a short while, as we cant purge
+            // For non logged in users we allow caching on shared proxies (mobile network accelerators, planes, ...)
+            // But only for a short while, as there is no way to purge them
             resp.http.cache-control = "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=300"
         }
     }

--- a/doc/varnish/vcl/varnish4_xkey.vcl
+++ b/doc/varnish/vcl/varnish4_xkey.vcl
@@ -65,12 +65,12 @@ sub vcl_recv {
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
         return (hash);
     }
+    
+    // Sort the query string for cache normalization.
+    set req.url = std.querysort(req.url);
 
     // Retrieve client user context hash and add it to the forwarded request.
     call ez_user_context_hash;
-
-    // Sort the query string for cache normalization.
-    set req.url = std.querysort(req.url);
 
     // If it passes all these tests, do a lookup anyway.
     return (hash);

--- a/doc/varnish/vcl/varnish4_xkey.vcl
+++ b/doc/varnish/vcl/varnish4_xkey.vcl
@@ -220,11 +220,11 @@ sub vcl_deliver {
         if (req.http.cookie) {
             // When in session where we vary by user hash we by default avoid caching this in shared proxies & browsers
             // For browser cache with it revalidating against varnish, use for instance "private, no-cache" instead
-            resp.http.cache-control = "private, no-cache, no-store, must-revalidate"
+            set resp.http.cache-control = "private, no-cache, no-store, must-revalidate";
         } else if (resp.http.cache-control ~ "public") {
             // For non logged in users we allow caching on shared proxies (mobile network accelerators, planes, ...)
             // But only for a short while, as there is no way to purge them
-            resp.http.cache-control = "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=300"
+            set resp.http.cache-control = "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=300";
         }
     }
 


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28126
> Epic: https://jira.ez.no/browse/EZP-27624

Improvement to our VCL in terms of not caching responses in Browser and shared proxy caches by default. And with inline suggestions for those that want to adapt it to be less strict or apply to all responses.


