### PR TITLE
[composer] Added oneup/flysystem-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "ezsystems/ezplatform-admin-ui-modules": "^1.0@dev",
         "ezsystems/ezplatform-http-cache": "^0.1@dev",
         "knplabs/knp-menu-bundle": "^2.1",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "oneup/flysystem-bundle": "^2.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.1",


### PR DESCRIPTION
# Description
Currently `2.0` cannot be installed due to the version constraint on `oneup/flysystem-bundle` in `ezsystems/ezpublish-kernel` which allows to install either `^1.0` or `^2.0`. Composer tends to install lower version which makes installation fail due to the BC break in `symfony/symfony` 3.4.0-BETA1. This PR forces `oneup/flysystem-bundle` installation in version 2.x.