### PR TITLE
[composer] Added config/bin-dir key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,9 @@
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
         ]
     },
+    "config": {
+        "bin-dir": "bin"
+    },
     "extra": {
         "symfony-app-dir": "app",
         "symfony-bin-dir": "bin",


### PR DESCRIPTION
# Description
`composer.json` on `2.0` branch is is missing `config/bin-dir` value which prevented behat from being installed into `bin/` folder. This change is required in order to run Behat tests on our repositories. 