### PR TITLE
Added Fastly params in config

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,12 @@ WEB_HOST=web
 SELENIUM_HOST=selenium
 
 # Enable recommendations by setting valid id, key and uri
+# In order for this to work you also need to have the EzSystemsRecommendationBundle installed
 #RECOMMENDATIONS_CUSTOMER_ID=""
 #RECOMMENDATIONS_LICENSE_KEY=""
 #PUBLIC_SERVER_URI=""
+
+# Enable fastly by setting valid service_id and key
+# In order for this to work you also need to have the EzSystemsPlatformFastlyCacheBundle installed
+#FASTLY_SERVICE_ID=""
+#FASTLY_KEY=""

--- a/.env
+++ b/.env
@@ -35,6 +35,6 @@ SELENIUM_HOST=selenium
 #PUBLIC_SERVER_URI=""
 
 # Enable fastly by setting valid service_id and key
-# In order for this to work you also need to have the EzSystemsPlatformFastlyCacheBundle installed
+# In order for this to work you also need to have the EE bundle EzSystemsPlatformFastlyCacheBundle installed
 #FASTLY_SERVICE_ID=""
 #FASTLY_KEY=""

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: default_parameters.yml }
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: env/docker.php }
+    - { resource: env/generic.php }
     - { resource: env/platformsh.php }
 
 # Configuration for Database connection, can have several connections used by eZ Repositories in ezplatform.yml

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -34,6 +34,9 @@ parameters:
     purge_type: "local"
     purge_server: "http://my.varnish.server:80"
 
+    fastly_service_id: default_service_id
+    fastly_key: default_fastly_key
+
     ## By default cache ttl is set to 24h, when using Varnish you can set a much higher value. High values depends on
     ## using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
     httpcache_default_ttl: 86400

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -107,19 +107,6 @@ if ($value = getenv('HTTPCACHE_DEFAULT_TTL')) {
     $container->setParameter('httpcache_default_ttl', $value);
 }
 
-// EzSystemsRecommendationsBundle settings
-if ($value = getenv('RECOMMENDATIONS_CUSTOMER_ID')) {
-    $container->setParameter('ez_recommendation.default.yoochoose.customer_id', $value);
-}
-
-if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
-    $container->setParameter('ez_recommendation.default.yoochoose.license_key', $value);
-}
-
-if ($value = getenv('PUBLIC_SERVER_URI')) {
-    $container->setParameter('ez_recommendation.default.server_uri', $value);
-}
-
 // EzSystemsPlatformFastlyCacheBundle settings
 if ($value = getenv('FASTLY_SERVICE_ID')) {
     $container->setParameter('fastly_service_id', $value);

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -107,6 +107,19 @@ if ($value = getenv('HTTPCACHE_DEFAULT_TTL')) {
     $container->setParameter('httpcache_default_ttl', $value);
 }
 
+// EzSystemsRecommendationsBundle settings
+if ($value = getenv('RECOMMENDATIONS_CUSTOMER_ID')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.customer_id', $value);
+}
+
+if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.license_key', $value);
+}
+
+if ($value = getenv('PUBLIC_SERVER_URI')) {
+    $container->setParameter('ez_recommendation.default.server_uri', $value);
+}
+
 // EzSystemsPlatformFastlyCacheBundle settings
 if ($value = getenv('FASTLY_SERVICE_ID')) {
     $container->setParameter('fastly_service_id', $value);

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -5,11 +5,6 @@
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader;
 
-if (getenv('DATABASE_HOST') === false) {
-    // Return if not DATABASE_HOST is set as that is needed to get things running with docker (shouldn't be on localhost)
-    return;
-}
-
 if ($value = getenv('SYMFONY_SECRET')) {
     $container->setParameter('secret', $value);
 }

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -90,12 +90,41 @@ if ($pool = getenv('CUSTOM_CACHE_POOL')) {
     $loader->load($pool . '.yml');
 }
 
-// HttpCache setting (for configuring Varnish purging)
+// HttpCache setting (for configuring http cache purging)
+if ($purgeType = getenv('HTTPCACHE_PURGE_TYPE')) {
+    $container->setParameter('purge_type', $purgeType);
+}
+
 if ($purgeServer = getenv('HTTPCACHE_PURGE_SERVER')) {
-    $container->setParameter('purge_type', 'http');
+    // BC : In earlier versions, purge_type was set automatically if purge_server was set
+    if ($purgeType === false) {
+        $container->setParameter('purge_type', 'varnish');
+    }
     $container->setParameter('purge_server', $purgeServer);
 }
 
 if ($value = getenv('HTTPCACHE_DEFAULT_TTL')) {
     $container->setParameter('httpcache_default_ttl', $value);
+}
+
+// EzSystemsRecommendationsBundle settings
+if ($value = getenv('RECOMMENDATIONS_CUSTOMER_ID')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.customer_id', $value);
+}
+
+if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.license_key', $value);
+}
+
+if ($value = getenv('PUBLIC_SERVER_URI')) {
+    $container->setParameter('ez_recommendation.default.server_uri', $value);
+}
+
+// EzSystemsPlatformFastlyCacheBundle settings
+if ($value = getenv('FASTLY_SERVICE_ID')) {
+    $container->setParameter('fastly_service_id', $value);
+}
+
+if ($value = getenv('FASTLY_KEY')) {
+    $container->setParameter('fastly_key', $value);
 }

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -1,5 +1,5 @@
 ezpublish:
-    # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'http' you can point it to Varnish
+    # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'varnish' you can point it to Varnish
     http_cache:
         purge_type: '%purge_type%'
 
@@ -37,6 +37,6 @@ ezpublish:
               # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
               # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
               default_ttl: '%httpcache_default_ttl%'
-            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
             http_cache:
+                # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'varnish'.
                 purge_servers: ['%purge_server%']

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -22,6 +22,8 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     networks:
      - backend
 

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -21,6 +21,8 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     networks:
      - backend
 

--- a/doc/docker/my-ez-app-stack.yml
+++ b/doc/docker/my-ez-app-stack.yml
@@ -36,11 +36,14 @@ services:
      - SYMFONY_HTTP_CACHE=0
      - SYMFONY_TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
+     - HTTPCACHE_PURGE_TYPE=varnish
      - PHP_INI_ENV_session.save_handler=redis
      - PHP_INI_ENV_session.save_path="tcp://redis:6379?weight=1"
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     volumes:
      - vardir:/var/www/web/var
     networks:

--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -11,6 +11,7 @@ services:
      - SYMFONY_HTTP_CACHE=0
      - SYMFONY_TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
+     - HTTPCACHE_PURGE_TYPE=varnish
 
   varnish:
     build:


### PR DESCRIPTION
This PR makes it possible to set Fastly configuration via environment variables, prepares the semantic configuration and make it a minimal effort for users to configure it once the fastly bundle has been installed

It also renames app/config/env/docker.php → app/config/env/generic.php as the file contains no docker specific stuff.

It might be a discussion if we should put this in platform or platform-ee as fastly will anyway not be available in platform. But recommendation is already partly here anyway ( I added the missing parts too ). 