### PR TITLE
EZP-28336 : app/config/env/docker.php is actually non-docker specific

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: default_parameters.yml }
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: env/docker.php }
+    - { resource: env/generic.php }
     - { resource: env/platformsh.php }
 
 # Configuration for Database connection, can have several connections used by eZ Repositories in ezplatform.yml

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -106,3 +106,16 @@ if ($purgeServer = getenv('HTTPCACHE_PURGE_SERVER')) {
 if ($value = getenv('HTTPCACHE_DEFAULT_TTL')) {
     $container->setParameter('httpcache_default_ttl', $value);
 }
+
+// EzSystemsRecommendationsBundle settings
+if ($value = getenv('RECOMMENDATIONS_CUSTOMER_ID')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.customer_id', $value);
+}
+
+if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
+    $container->setParameter('ez_recommendation.default.yoochoose.license_key', $value);
+}
+
+if ($value = getenv('PUBLIC_SERVER_URI')) {
+    $container->setParameter('ez_recommendation.default.server_uri', $value);
+}

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -90,9 +90,16 @@ if ($pool = getenv('CUSTOM_CACHE_POOL')) {
     $loader->load($pool . '.yml');
 }
 
-// HttpCache setting (for configuring Varnish purging)
+// HttpCache setting (for configuring http cache purging)
+if ($purgeType = getenv('HTTPCACHE_PURGE_TYPE')) {
+    $container->setParameter('purge_type', $purgeType);
+}
+
 if ($purgeServer = getenv('HTTPCACHE_PURGE_SERVER')) {
-    $container->setParameter('purge_type', 'http');
+    // BC : In earlier versions, purge_type was set automatically if purge_server was set
+    if ($purgeType === false) {
+        $container->setParameter('purge_type', 'http');
+    }
     $container->setParameter('purge_server', $purgeServer);
 }
 

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -5,11 +5,6 @@
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader;
 
-if (getenv('DATABASE_HOST') === false) {
-    // Return if not DATABASE_HOST is set as that is needed to get things running with docker (shouldn't be on localhost)
-    return;
-}
-
 if ($value = getenv('SYMFONY_SECRET')) {
     $container->setParameter('secret', $value);
 }

--- a/doc/docker/my-ez-app-stack.yml
+++ b/doc/docker/my-ez-app-stack.yml
@@ -36,6 +36,7 @@ services:
      - SYMFONY_HTTP_CACHE=0
      - SYMFONY_TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
+     - HTTPCACHE_PURGE_TYPE=http
      - PHP_INI_ENV_session.save_handler=redis
      - PHP_INI_ENV_session.save_path="tcp://redis:6379?weight=1"
      - RECOMMENDATIONS_CUSTOMER_ID

--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -11,6 +11,7 @@ services:
      - SYMFONY_HTTP_CACHE=0
      - SYMFONY_TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
+     - HTTPCACHE_PURGE_TYPE=http
 
   varnish:
     build:


### PR DESCRIPTION
This PR does the following:
- renames app/config/env/docker.php → app/config/env/generic.php as the file contains no docker specific stuff.
- adds possibility to set purge_type via environment variable HTTPCACHE_PURGE_TYPE
- adds possibility to set recommendation settings via environment variables

Note:
When merging this to ezplatform-ee-demo, please note that the recommencation settings are already in docker.php (generic.php) ... Make sure that code is not duplicated, and that is is located  at the same spot in the file to avoid further merge conflicts.