### PR TITLE
EZP-28375: As a Maintainer I want CI to run tests on behat environment of eZ Platform v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,14 @@ before_install: ./bin/.travis/trusty/update_docker.sh
 before_script:
   # Internal auth token dedicated to testing with travis+composer on ezsystems repos, not for reuse!
   - echo "{\"github-oauth\":{\"github.com\":\"d0285ed5c8644f30547572ead2ed897431c1fc09\"}}" > auth.json
-  # In case of dev mode we'll need to install composer packages first
-  - docker-compose -f doc/docker/install.yml up --abort-on-container-exit
-  # Run (start containers and execute install command)
-  - docker-compose up -d
+  # Setup eZ Platform inside docker container
+  - /bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" "${INSTALL_EZ_INSTALL_TYPE}"
   #- docker ps
   #- docker-compose logs
 
 # Execute test command, need to use sh to get right exit code (docker/compose/issues/3379)
 # Behat will use behat.yml which is a copy of behat.yml.dist with hostnames update by doc/docker/selenium.yml
-script: docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php $TEST_CMD"
+script: docker-compose exec --user www-data app sh -c "php $TEST_CMD"
 
 after_failure:
   # Will show us the last bit of the log of container's main processes

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_script:
   - echo "{\"github-oauth\":{\"github.com\":\"d0285ed5c8644f30547572ead2ed897431c1fc09\"}}" > auth.json
   # Setup eZ Platform inside docker container
   - /bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" "${INSTALL_EZ_INSTALL_TYPE}"
+  # Execute Symfony command if injected into test matrix
+  - if [ "${SYMFONY_CMD}" != "" ] ; then docker-compose exec --user www-data app sh -c "bin/console ${SYMFONY_CMD}" ; fi
   #- docker ps
   #- docker-compose logs
 

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -38,7 +38,7 @@ class AppKernel extends Kernel
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
-            // new EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle(),
+            new EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle(),
             new EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle(),
             new EzSystems\EzPlatformAdminUiModulesBundle\EzPlatformAdminUiModulesBundle(),
             new EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle(),

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -46,16 +46,19 @@ class AppKernel extends Kernel
             new AppBundle\AppBundle(),
         ];
 
-        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
-            $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
-            $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
-            $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-
-            if ('dev' === $this->getEnvironment()) {
-                $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+        switch ($this->getEnvironment()) {
+            case 'test':
+            case 'behat':
+                $bundles[] = new EzSystems\BehatBundle\EzSystemsBehatBundle();
+                $bundles[] = new EzSystems\PlatformBehatBundle\EzPlatformBehatBundle();
+            // No break, test also needs dev bundles
+            case 'dev':
                 $bundles[] = new eZ\Bundle\EzPublishDebugBundle\EzPublishDebugBundle();
-            }
+                $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
+                $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+                $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+                $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
         }
 
         return $bundles;

--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -1,2 +1,19 @@
 imports:
-    - { resource: config_prod.yml }
+    - { resource: config_dev.yml }
+    - { resource: ezplatform_behat.yml }
+
+framework:
+    router:
+        resource: "%kernel.root_dir%/config/routing_behat.yml"
+    profiler:
+        collect: false
+
+web_profiler:
+    toolbar: false
+    intercept_redirects: false
+
+swiftmailer:
+    disable_delivery: true
+
+assetic:
+    use_controller: false

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -24,6 +24,8 @@ default:
                 env: behat
                 debug: false
 
+        EzSystems\PlatformBehatBundle\ServiceContainer\EzBehatExtension: ~
+
     suites: ~
 
 imports:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -33,3 +33,4 @@ imports:
     - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/behat_suites.yml
     - vendor/ezsystems/repository-forms/behat_suites.yml
     - vendor/ezsystems/ezplatform-admin-ui/behat_suites.yml
+    - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/behat_suites.yml

--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -31,40 +31,18 @@ fi
 if [[ -n "${DEPENDENCY_PACKAGE_DIR}" ]]; then
     # Get details about dependency package
     DEPENDENCY_PACKAGE_NAME=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->name;"`
-    DEPENDENCY_BRANCH_ALIAS=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->extra->{'branch-alias'}->{'dev-master'};"`
 
     if [[ -z "${DEPENDENCY_PACKAGE_NAME}" ]]; then
         echo 'Missing composer package name of tested dependency' >&2
         exit 3
     fi
-
-    if [[ -z "${DEPENDENCY_BRANCH_ALIAS}" ]]; then
-        echo 'Missing composer branch alias of tested dependency' >&2
-        exit 4
-    fi
-
-    # Use package name as directory name for better readability
-    TESTED_DEPENDENCY_DIR=`basename ${DEPENDENCY_PACKAGE_NAME}`
-    # Move package into location accessible by docker container
-    echo "> Move '${DEPENDENCY_PACKAGE_DIR}' to '${TESTED_DEPENDENCY_DIR}'"
-    mv ${DEPENDENCY_PACKAGE_DIR} ${TESTED_DEPENDENCY_DIR}
-
-    echo "> Modify eZ Platform composer.json to point to local checkout of ${DEPENDENCY_PACKAGE_NAME}"
-    composer config repositories.tested_dependency path ${TESTED_DEPENDENCY_DIR}
-
-    # require dependency using branch-alias version so local checkout gets symlinked
-    COMPOSER_REQUIRE="${DEPENDENCY_PACKAGE_NAME}:${DEPENDENCY_BRANCH_ALIAS}"
-    echo "> Requiring packages: $COMPOSER_REQUIRE"
-    composer require --no-update "${COMPOSER_REQUIRE}"
 fi
 
 echo '> Preparing eZ Platform container using the following setup:'
 echo "- EZPLATFORM_BUILD_DIR=${EZPLATFORM_BUILD_DIR}"
 echo "- COMPOSE_FILE=${COMPOSE_FILE}"
-if [[ -n "${DEPENDENCY_PACKAGE_DIR}" ]]; then
+if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
     echo "- DEPENDENCY_PACKAGE_NAME=${DEPENDENCY_PACKAGE_NAME}"
-    echo "- DEPENDENCY_PACKAGE_DIR=${DEPENDENCY_PACKAGE_DIR}"
-    echo "- DEPENDENCY_BRANCH_ALIAS=${DEPENDENCY_BRANCH_ALIAS}"
 fi
 
 echo '> Remove XDebug PHP extension'
@@ -76,6 +54,21 @@ docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 
 echo '> Run composer install inside docker app container'
 docker-compose exec --user www-data app sh -c 'COMPOSER_HOME=$HOME/.composer composer install --no-suggest --no-progress --no-interaction --prefer-dist --optimize-autoloader'
+
+# Handle dependency if needed
+if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
+    # check if dependency exists for current meta-package version
+    if [[ ! -d "./vendor/${DEPENDENCY_PACKAGE_NAME}" ]]; then
+        echo "Testing dependency failed: package ${DEPENDENCY_PACKAGE_NAME} does not exist" >&2
+        exit 4
+    fi
+
+    echo "> Overwrite ./vendor/${DEPENDENCY_PACKAGE_NAME} with ${DEPENDENCY_PACKAGE_DIR}"
+    rm -rf "./vendor/${DEPENDENCY_PACKAGE_NAME}" && mv ${DEPENDENCY_PACKAGE_DIR} "./vendor/${DEPENDENCY_PACKAGE_NAME}"
+
+    echo '> Clear Symfony cache inside docker app container'
+    docker-compose exec --user www-data app sh -c 'php ./bin/console cache:clear --no-warmup && php ./bin/console cache:warmup'
+fi
 
 echo '> Install data'
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ezplatform:install ${INSTALL_TYPE}"

--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# This script provides setup steps needed to build eZ Platform docker containers ready to execute
+# functional and acceptance (behat) tests.
+#
+# Example usage:
+# $ ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" "${INSTALL_TYPE}" ["${DEPENDENCY_PACKAGE_DIR}"]
+#
+# Arguments:
+# - ${COMPOSE_FILE}           compose file(s) paths
+# - ${INSTALL_TYPE}           eZ Platform install type ("clean")
+# - ${DEPENDENCY_PACKAGE_DIR} optional, directory containing existing eZ Platform dependency package
+
+COMPOSE_FILE=$1
+INSTALL_TYPE=$2
+DEPENDENCY_PACKAGE_DIR=$3
+
+# Determine eZ Platform Build dir as relative to current script path
+EZPLATFORM_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+
+if [[ -z "${COMPOSE_FILE}" ]]; then
+    echo 'Argument 1 should contain path to compose file(s). None given.' >&2
+    exit 1
+fi
+
+if [[ -z "${INSTALL_TYPE}" ]]; then
+    echo 'Argument 2 should contain eZ Platform install type. None given' >&2
+    exit 2
+fi
+
+if [[ -n "${DEPENDENCY_PACKAGE_DIR}" ]]; then
+    # Get details about dependency package
+    DEPENDENCY_PACKAGE_NAME=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->name;"`
+    DEPENDENCY_BRANCH_ALIAS=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->extra->{'branch-alias'}->{'dev-master'};"`
+
+    if [[ -z "${DEPENDENCY_PACKAGE_NAME}" ]]; then
+        echo 'Missing composer package name of tested dependency' >&2
+        exit 3
+    fi
+
+    if [[ -z "${DEPENDENCY_BRANCH_ALIAS}" ]]; then
+        echo 'Missing composer branch alias of tested dependency' >&2
+        exit 4
+    fi
+
+    # Use package name as directory name for better readability
+    TESTED_DEPENDENCY_DIR=`basename ${DEPENDENCY_PACKAGE_NAME}`
+    # Move package into location accessible by docker container
+    echo "> Move '${DEPENDENCY_PACKAGE_DIR}' to '${TESTED_DEPENDENCY_DIR}'"
+    mv ${DEPENDENCY_PACKAGE_DIR} ${TESTED_DEPENDENCY_DIR}
+
+    echo "> Modify eZ Platform composer.json to point to local checkout of ${DEPENDENCY_PACKAGE_NAME}"
+    composer config repositories.tested_dependency path ${TESTED_DEPENDENCY_DIR}
+
+    # require dependency using branch-alias version so local checkout gets symlinked
+    COMPOSER_REQUIRE="${DEPENDENCY_PACKAGE_NAME}:${DEPENDENCY_BRANCH_ALIAS}"
+    echo "> Requiring packages: $COMPOSER_REQUIRE"
+    composer require --no-update "${COMPOSER_REQUIRE}"
+fi
+
+echo '> Preparing eZ Platform container using the following setup:'
+echo "- EZPLATFORM_BUILD_DIR=${EZPLATFORM_BUILD_DIR}"
+echo "- COMPOSE_FILE=${COMPOSE_FILE}"
+if [[ -n "${DEPENDENCY_PACKAGE_DIR}" ]]; then
+    echo "- DEPENDENCY_PACKAGE_NAME=${DEPENDENCY_PACKAGE_NAME}"
+    echo "- DEPENDENCY_PACKAGE_DIR=${DEPENDENCY_PACKAGE_DIR}"
+    echo "- DEPENDENCY_BRANCH_ALIAS=${DEPENDENCY_BRANCH_ALIAS}"
+fi
+
+echo '> Remove XDebug PHP extension'
+phpenv config-rm xdebug.ini
+
+echo "> Start docker containers specified by ${COMPOSE_FILE}"
+docker-compose up -d
+docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
+
+echo '> Run composer install inside docker app container'
+docker-compose exec --user www-data app sh -c 'COMPOSER_HOME=$HOME/.composer composer install --no-suggest --no-progress --no-interaction --prefer-dist --optimize-autoloader'
+
+echo '> Install data'
+docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ezplatform:install ${INSTALL_TYPE}"
+
+echo '> Done, ready to run tests'

--- a/bin/.travis/trusty/setup_from_external_repo.sh
+++ b/bin/.travis/trusty/setup_from_external_repo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# @deprecated since 2.0, use ./bin/.travis/trusty/setup_ezplatform.sh
+#
 # This script is meant to be reused from other repos that needs to run behat tests.
 #
 # It assumes you have already checked pout ezplatform (to get access to this script) and
@@ -20,6 +22,8 @@
 #  - ./bin/.travis/trusty/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/demobundle:dev-tmp_travis_branch"
 #
 # script: docker-compose run -u www-data --rm behatphpcli bin/behat --profile=rest --suite=fullJson --tags=~@broken
+
+echo 'The script setup_from_external_repo is deprecated. Use ./bin/.travis/trusty/setup_ezplatform.sh instead.' >&2
 
 REPO_DIR=$1
 COMPOSER_REQUIRE=${@:2}

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "behat/mink-extension": "~2.0",
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "~1.0",
+        "phpunit/phpunit": "^6.4",
         "sensio/generator-bundle": "~3.1",
         "symfony/phpunit-bridge": "~3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "behat/mink-extension": "~2.0",
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "~1.0",
+        "ezsystems/behatbundle": "^6.5",
         "phpunit/phpunit": "^6.4",
         "sensio/generator-bundle": "~3.1",
         "symfony/phpunit-bridge": "~3.2"

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "ezsystems/ezplatform-admin-ui": "^1.0@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.0@dev",
         "ezsystems/ezplatform-admin-ui-assets": "^0.4",
+        "ezsystems/ezplatform-design-engine": "^1.1",
         "knplabs/knp-menu-bundle": "^2.1",
         "sensio/framework-extra-bundle": "^3.0.2",
         "willdurand/js-translation-bundle": "^2.6.4",


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Ready for a review |
| **JIRA issue** | [EZP-28375](https://jira.ez.no/browse/EZP-28375) |
| **Target version** | `2.0` |
| **BC break** | yes, for automated tests |

This PR improves running tests which require running eZ Platform installation (behat, REST functional) by moving most of setup logic to script which is a part of this meta-repository.

**TODO**
- [x] **Before merge: remove TMP commit**.
- [x] Fix CI tests run for branches and PRs opened against this meta-repository.
- [x] Add dependency on `phpunit/phpunit`.
- [x] Add dependency on `ezsystems/behatbundle`
- ~Improve docker upgrade script.~ *removed after review*
- [x] Deprecate `setup_from_external_repo` script
- [x] Introduce `setup_ezplatform` script creating dockerized environment for tests run at dependent repositories.
- [x] Enabled all necessary test/behat bundles.
