### PR TITLE
Refactor param names to keep BC with eZ Platform 1.x while still allowing fallback to env vars

### DIFF
--- a/app/config/cache_pool/cache.memcached.yml
+++ b/app/config/cache_pool/cache.memcached.yml
@@ -7,4 +7,4 @@ services:
               clearer: cache.app_clearer
               # Example from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/MemcachedTrait.php:
               # memcached://user:pass@localhost?weight=33'
-              provider: 'memcached://%env(CACHE_DSN)%'
+              provider: 'memcached://%cache_dsn%'

--- a/app/config/cache_pool/cache.redis.yml
+++ b/app/config/cache_pool/cache.redis.yml
@@ -9,4 +9,4 @@ services:
               # redis://localhost:6379
               # redis://secret@example.com:1234/13
               # redis://secret@/var/run/redis.sock/13?persistent_id=4&class=Redis&timeout=3&retry_interval=3
-              provider: 'redis://%env(CACHE_DSN)%'
+              provider: 'redis://%cache_dsn%'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,12 +17,12 @@ doctrine:
     dbal:
         connections:
             default:
-                driver: '%env(DATABASE_DRIVER)%'
-                host: '%env(DATABASE_HOST)%'
-                port: '%env(DATABASE_PORT)%'
-                dbname: '%env(DATABASE_NAME)%'
-                user: '%env(DATABASE_USER)%'
-                password: '%env(DATABASE_PASSWORD)%'
+                driver: '%database_driver%'
+                host: '%database_host%'
+                port: '%database_port%'
+                dbname: '%database_name%'
+                user: '%database_user%'
+                password: '%database_password%'
                 charset: UTF8
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
@@ -34,8 +34,8 @@ doctrine:
 ez_search_engine_solr:
     endpoints:
         endpoint0:
-            dsn: '%env(SOLR_DSN)%'
-            core: '%env(SOLR_CORE)%'
+            dsn: '%solr_dsn%'
+            core: '%solr_core%'
     connections:
         default:
             entry_endpoints:
@@ -46,7 +46,7 @@ ez_search_engine_solr:
 framework:
     esi: ~
     translator: { fallback: '%locale_fallback%' }
-    secret: '%env(SYMFONY_SECRET)%'
+    secret: '%secret%'
     router:
         resource: '%kernel.project_dir%/app/config/routing.yml'
         strict_requirements: ~
@@ -94,9 +94,9 @@ assetic:
 # Swiftmailer Configuration
 swiftmailer:
     transport: '%mailer_transport%'
-    host: '%env(MAILER_HOST)%'
-    username: '%env(MAILER_USER)%'
-    password: '%env(MAILER_PASSWORD)%'
+    host: '%mailer_host%'
+    username: '%mailer_user%'
+    password: '%mailer_password%'
     spool: { type: memory }
 
 # FOSHttpCache Configuration

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -16,7 +16,7 @@ monolog:
     handlers:
         main:
             type: '%log_type%'
-            path: '%env(LOG_PATH)%'
+            path: '%log_path%'
             level: debug
             channels: ['!event']
         console:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -17,7 +17,7 @@ monolog:
             handler: nested
         nested:
             type: '%log_type%'
-            path: '%env(LOG_PATH)%'
+            path: '%log_path%'
             level: debug
         console:
             type: console

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -2,31 +2,64 @@
 parameters:
     locale_fallback: en
 
+    # A secret key that's used to generate certain security-related tokens
+    secret: '%env(SYMFONY_SECRET)%'
+
+    # Settings for database backend used by Doctrine DBAL
+    # In turn used for default storage engine & default search engine (if legacy is configured as search engine)
+    database_driver: '%env(DATABASE_DRIVER)%'
+    database_host: '%env(DATABASE_HOST)%'
+    database_port: '%env(DATABASE_PORT)%'
+    database_name: '%env(DATABASE_NAME)%'
+    database_user: '%env(DATABASE_USER)%'
+    database_password: '%env(DATABASE_PASSWORD)%'
+
     # Setting for mail system, used by SwiftMailer
+    mailer_host: '%env(MAILER_HOST)%'
+    mailer_user: '%env(MAILER_USER)%'
+    mailer_password: '%env(MAILER_PASSWORD)%'
+
+    # One of `legacy` (default) or `solr`
+    search_engine: '%env(SEARCH_ENGINE)%'
+
+    # Solr root endpoint, relevant if `solr` is set as search_engine
+    solr_dsn: '%env(SOLR_DSN)%'
+    solr_core: '%env(SOLR_CORE)%'
+
+    # Log path, where to store the log files. php://stderr may be used in order to log to standard error
+    log_path: '%env(LOG_PATH)%'
+
+    # Settings for Cache pool, to change add own cache service and optionally inject own arguments
+    # predefined pools: see symfony config and the optional pools in app/config/cache_pool/
+    cache_pool: '%env(CACHE_POOL)%'
+
+    # Cache DSN, see app/config/services/cache.yml for examples:
+    cache_dsn: '%env(CACHE_DSN)%'
+
+    # Settings for HttpCache
+    purge_servers: '%env(PURGE_SERVERS)%'
+
+    # By default cache ttl is set to 24h, when using Varnish you can set a much higher value. High values depends on
+    # using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
+    httpcache_ttl: '%env(HTTPCACHE_TTL)%'
+
+    # Fallback values for when environment variables do not exist
+
     env(MAILER_HOST):       127.0.0.1
     env(MAILER_USER):       ~
     env(MAILER_PASSWORD):   ~
 
-    # One of `legacy` (default) or `solr`
     env(SEARCH_ENGINE): legacy
 
-    # Solr root endpoint, relevant if `solr` is set as search_engine
     env(SOLR_DSN): http://localhost:8983/solr
     env(SOLR_CORE): collection1
 
-    # Log path, where to store the log files. php://stderr may be used in order to log to standard error
     env(LOG_PATH): "%kernel.logs_dir%/%kernel.environment%.log"
 
-    # Settings for Cache pool, to change add own cache service and optionally inject own arguments
-    # predefined pools: see symfony config and the optional pools in app/config/cache_pool/
     env(CACHE_POOL): "cache.app"
 
-    # Cache DSN, see app/config/services/cache.yml for examples:
     env(CACHE_DSN): localhost
 
-    # Settings for HttpCache
     env(PURGE_SERVERS): "http://localhost:80"
 
-    ## By default cache ttl is set to 24h, when using Varnish you can set a much higher value. High values depends on
-    ## using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
     env(HTTPCACHE_TTL): 86400

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -8,7 +8,7 @@ ezpublish:
         default:
             storage: ~
             search:
-                engine: '%env(SEARCH_ENGINE)%'
+                engine: '%search_engine%'
                 connection: default
 
     # Siteaccess configuration, with one siteaccess per default
@@ -24,7 +24,7 @@ ezpublish:
     system:
         site_group:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
-            cache_service_name: '%env(CACHE_POOL)%'
+            cache_service_name: '%cache_pool%'
             # These reflect the current installers, complete installation before you change them. For changing var_dir
             # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
             # need to manually modify your database data to reflect this to avoid exceptions.
@@ -36,10 +36,10 @@ ezpublish:
             content:
               # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
               # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
-              default_ttl: '%env(HTTPCACHE_TTL)%'
+              default_ttl: '%httpcache_ttl%'
             # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
             http_cache:
-                purge_servers: ['%env(PURGE_SERVERS)%']
+                purge_servers: ['%purge_servers%']
             # Temporary hard coding session name during v2 development
             session:
                 name: eZSESSID


### PR DESCRIPTION
This changes param names back to "human readable" format to keep BC with eZ Platform 1.x, while still allowing for fallback to environment variables or if environment variables do not exist, fallback to values specified with `'%env(ENV_NAME)%'` format.

This is the same what Sylius does with their parameters: https://github.com/Sylius/Sylius/blob/master/app/config/parameters.yml.dist