### PR TITLE
EZP-27752: [Travis] Injected ez:behat:create-language command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - TEST_CMD="bin/behat -vv --profile=rest --suite=fullJson --tags=~@broken" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
     - TEST_CMD="bin/behat -vv --profile=rest --suite=fullXml --tags=~@broken"
     - TEST_CMD="bin/behat -vv --profile=core --tags=~@broken"
-    - TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
+    - TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional" SYMFONY_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
 
 # test only master (+ Pull requests)

--- a/doc/docker/install.yml
+++ b/doc/docker/install.yml
@@ -22,6 +22,7 @@ services:
     environment:
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG
+     - SYMFONY_CMD
      - DATABASE_USER
      - DATABASE_PASSWORD
      - DATABASE_NAME
@@ -34,6 +35,7 @@ services:
       mkdir -p web/var;
       php /scripts/wait_for_db.php;
       php app/console ezplatform:install ${INSTALL_EZ_INSTALL_TYPE};
+      if [ \"$SYMFONY_CMD\" != '' ]; then echo '> Executing' \"$SYMFONY_CMD\"; php app/console $SYMFONY_CMD; fi;
       rm -Rf app/logs/* app/cache/*/*;
       chown -R www-data:www-data app/cache app/logs web/var;
       find app/cache app/logs web/var -type d -print0 | xargs -0 chmod -R 775;


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Ready for review |
| **JIRA issue** | [EZP-27752](https://jira.ez.no/browse/EZP-27752) |
| **Bug fix** | yes |
| **BC break** | no |
| **Target version** | `1.13` |
| **Tests pass** | yes |

This PR fixes running REST functional tests by adding missing new language required by these tests.

**TODO**:
- [x] Inject `ez:behat:create-language` Symfony command into Travis test matrix job.
- [x] Add executing injected Symfony command inside Docker app container. // not possible, had to be added inside docker compose file `install.yml`
- [x] Wait for Travis to confirm.