### PR TITLE
[Travis] Fixed setup_ezplatform.sh to make composer use local dependency

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -77,22 +77,25 @@ fi
 
 echo "> Start docker containers specified by ${COMPOSE_FILE}"
 docker-compose up -d
-docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 
 if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
     # use local checkout path relative to docker volume
     echo "> Make composer use tested dependency local checkout ${TMP_TRAVIS_BRANCH} of ${BASE_PACKAGE_NAME}"
-    docker-compose exec --user www-data app sh -c "COMPOSER_HOME=~/.composer composer config repositories.localDependency git ~/${BASE_PACKAGE_NAME}"
+    docker-compose exec app sh -c "composer config repositories.localDependency git /var/www/${BASE_PACKAGE_NAME}"
 
     echo "> Require ${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"
-    if ! docker-compose exec --user www-data app sh -c "COMPOSER_HOME=~/.composer composer require --no-update '${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}'"; then
+    if ! docker-compose exec app sh -c "composer require --no-update '${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}'"; then
         echo 'Failed requiring dependency' >&2
         exit 3
     fi
 fi
 
 echo '> Run composer install inside docker app container'
-docker-compose exec --user www-data app sh -c 'COMPOSER_HOME=~/.composer composer install --no-suggest --no-progress --no-interaction --prefer-dist --optimize-autoloader'
+docker-compose exec app sh -c 'composer install --no-suggest --no-progress --no-interaction --prefer-dist --optimize-autoloader'
+
+# for behat builds to work
+echo '> Change ownership of files inside docker container'
+docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 
 echo '> Install data'
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ezplatform:install ${INSTALL_TYPE}"

--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -54,9 +54,9 @@ phpenv config-rm xdebug.ini
 # Handle dependency if needed
 if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
     # get dependency branch alias
-    BRANCH_ALIAS=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->extra->{'branch-alias'}->{'dev-master'};"`
+    BRANCH_ALIAS=`php -r "echo json_decode(file_get_contents('${DEPENDENCY_PACKAGE_DIR}/composer.json'))->extra->{'branch-alias'}->{'dev-tmp_ci_branch'};"`
     if [[ $? -ne 0 || -z "${BRANCH_ALIAS}" ]]; then
-        echo 'Failed to determine branch alias. Add extra.branch-alias.dev-master config key to your tested dependency composer.json' >&2
+        echo 'Failed to determine branch alias. Add extra.branch-alias.dev-tmp_ci_branch config key to your tested dependency composer.json' >&2
         exit 3
     fi
 


### PR DESCRIPTION
This PR fixes `setup_ezplatform.sh` when used by dependencies to make composer install proper local checkout at the beginning. 

While my initial approach was faster it didn't take into account proper composer workflow (scripts, cache, etc.).

**TODO**
- [x] Check if it works with some dependencies, ref. [ezpublish-kernel build](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/318550839), [ezplatform-admin-ui build](https://travis-ci.org/ezsystems/ezplatform-admin-ui/jobs/318747707)
- [x] Wait here for Travis, ref. [ezplatform build](https://travis-ci.org/ezsystems/ezplatform/builds/318525368)