### PR TITLE
EZP-28637: Remove Bootstrap 3 references from application config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -79,8 +79,6 @@ framework:
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
-    form_themes:
-        - 'bootstrap_3_layout.html.twig'
 
 # Assetic Configuration
 assetic:


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28637

# Description
This setting would mess forms in whole application which could generate some problems in frontend forms. AdminUI will set theme explicitly.