### PR TITLE
Fix SYMFONY_TMP_DIR when defined

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -72,7 +72,7 @@ class AppKernel extends Kernel
     public function getCacheDir()
     {
         if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
-            return dirname($_SERVER['SYMFONY_TMP_DIR']) . '/var/cache/' . $this->getEnvironment();
+            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/var/cache/' . $this->getEnvironment();
         }
 
         return dirname(__DIR__) . '/var/cache/' . $this->getEnvironment();
@@ -81,7 +81,7 @@ class AppKernel extends Kernel
     public function getLogDir()
     {
         if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
-            return dirname($_SERVER['SYMFONY_TMP_DIR']) . '/var/logs';
+            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/var/logs';
         }
 
         return dirname(__DIR__) . '/var/logs';


### PR DESCRIPTION
dirname of /tmp would return /, native dirname(__DIR__) function return the parent of app which is good. But not in the SYMFONY_TMP_DIR case.