### PR TITLE
EZP-28714: Allow trusted proxy env to be set when symfony proxy is off

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -40,6 +40,8 @@ if ($useHttpCache) {
     Request::enableHttpMethodParameterOverride();
 }
 
+$request = Request::createFromGlobals();
+
 // If behind one or more trusted proxies, you can set them in SYMFONY_TRUSTED_PROXIES environment variable.
 // Proxies here refers to things like load balancers, TLS/Reverse proxies and so on, which symfony need to know about to
 // work correctly: To identify https, allow lookups to private routes like /__fos_user_context_hash for Varnish, ...
@@ -50,7 +52,6 @@ if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
 }
 
-$request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/web/app.php
+++ b/web/app.php
@@ -26,23 +26,25 @@ if ($useDebugging) {
 $kernel = new AppKernel($environment, $useDebugging);
 
 // Depending on the SYMFONY_HTTP_CACHE environment variable, tells whether the internal HTTP Cache mechanism is to be used.
+// Recommendation is to use Varnish over this, for performance and being able to setup cluster if you need to.
 // If not set, or "", it is auto activated if _not_ in "dev" environment.
 if (($useHttpCache = getenv('SYMFONY_HTTP_CACHE')) === false || $useHttpCache === '') {
     $useHttpCache = $environment !== 'dev';
 }
 
-// Load HTTP Cache ...
+// Load internal HTTP Cache, aka Symfony Proxy, if enabled
 if ($useHttpCache) {
     $kernel = new AppCache($kernel);
 
-    // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
+    // When using the Symfony Proxy, we'll need to call this method in this front controller instead of relying on the configuration parameter
     Request::enableHttpMethodParameterOverride();
+}
 
-    // If you are behind one or more trusted reverse proxies, you might want to set them in SYMFONY_TRUSTED_PROXIES environment
-    // variable in order to get correct client IP. NOTE: As per Symfony doc you will need to customize these lines for your proxy!
-    if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {
-        Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
-    }
+// If behind one or more trusted reverse proxies, you can set them in SYMFONY_TRUSTED_PROXIES environment variable.
+// NOTE: As per Symfony doc you will need to customize these lines for your proxy depending on forward headers to use!
+// See: https://symfony.com/doc/3.4/deployment/proxies.html
+if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {
+    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
 }
 
 $request = Request::createFromGlobals();

--- a/web/app.php
+++ b/web/app.php
@@ -43,8 +43,8 @@ if ($useHttpCache) {
 $request = Request::createFromGlobals();
 
 // If behind one or more trusted proxies, you can set them in SYMFONY_TRUSTED_PROXIES environment variable.
-// Proxies here refers to things like load balancers, TLS/Reverse proxies and so on, which symfony need to know about to
-// work correctly: To identify https, allow lookups to private routes like /__fos_user_context_hash for Varnish, ...
+// !! Proxies here refers to load balancers, TLS/Reverse proxies and so on. Which Symfony need to know about to
+// work correctly: identify https, allow Varnish to lookup fragment & user hash routes, get correct client ip, ...
 //
 // NOTE: You'll potentially need to customize these lines for your proxy depending on which forward headers to use!
 // SEE: https://symfony.com/doc/3.4/deployment/proxies.html

--- a/web/app.php
+++ b/web/app.php
@@ -36,13 +36,16 @@ if (($useHttpCache = getenv('SYMFONY_HTTP_CACHE')) === false || $useHttpCache ==
 if ($useHttpCache) {
     $kernel = new AppCache($kernel);
 
-    // When using the Symfony Proxy, we'll need to call this method in this front controller instead of relying on the configuration parameter
+    // Needed when using Synfony proxy, see: http://symfony.com/doc/3.4/reference/configuration/framework.html#http-method-override
     Request::enableHttpMethodParameterOverride();
 }
 
-// If behind one or more trusted reverse proxies, you can set them in SYMFONY_TRUSTED_PROXIES environment variable.
-// NOTE: As per Symfony doc you will need to customize these lines for your proxy depending on forward headers to use!
-// See: https://symfony.com/doc/3.4/deployment/proxies.html
+// If behind one or more trusted proxies, you can set them in SYMFONY_TRUSTED_PROXIES environment variable.
+// Proxies here refers to things like load balancers, TLS/Reverse proxies and so on, which symfony need to know about to
+// work correctly: To identify https, allow lookups to private routes like /__fos_user_context_hash for Varnish, ...
+//
+// NOTE: You'll potentially need to customize these lines for your proxy depending on which forward headers to use!
+// SEE: https://symfony.com/doc/3.4/deployment/proxies.html
 if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28714
> Replaces: #250


TL;DR; Anyone using Varnish for instance will need this, as they are supposed to disable symfony proxy and pass in trusted ip's for varnish (and tls proxy if there is one).

Review ping @wizhippo 
  