### PR TITLE
Use Redis-based sessions if Redis is available

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -21,7 +21,7 @@ relationships:
     database: 'mysqldb:mysql'
     rediscache: 'rediscache:redis'
     # If you wish to have a separate Redis instance for sessions, uncomment
-    # this relationship and the corresponding service in .platform.app.yaml.
+    # this relationship and the corresponding service in .platform/services.yaml
     #redissession: 'redissession:redis'
 
 # The configuration of app when it is exposed to the web.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -18,7 +18,11 @@ build:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: 'mysqldb:mysql'
+    rediscache: 'rediscache:redis'
+    # If you wish to have a separate Redis instance for sessions, uncomment
+    # this relationship and the corresponding service in .platform.app.yaml.
+    #redissession: 'redissession:redis'
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -78,3 +78,4 @@ runtime:
         - xsl
         - imagick
         - readline
+        - redis

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,3 +1,11 @@
 mysqldb:
     type: mysql:10.0
     disk: 2048
+
+rediscache:
+    type: 'redis:3.2'
+
+# If you wish to have a separate Redis instance for sessions, uncomment
+# this service and the corresponding relationship in .platform.app.yaml.
+#redissession:
+#  type: 'redis:3.2'

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -8,4 +8,10 @@ rediscache:
 # If you wish to have a separate Redis instance for sessions, uncomment
 # this service and the corresponding relationship in .platform.app.yaml.
 #redissession:
-#  type: 'redis:3.2'
+#    type: 'redis:3.2'
+#
+# Alternatively if you have a requirement that sessions are persisted across server restarts,
+# have storage space to spare for this, and don't mind a bit slower instance type of redis
+#redissession:
+#    type: redis-persistent:3.2
+#    disk: 1024

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -10,7 +10,7 @@ rediscache:
 #redissession:
 #    type: 'redis:3.2'
 #
-# Alternatively if you have a requirement that sessions are persisted across server restarts,
+# Alternatively if you have a requirement that sessions are persisted across server/redis restarts,
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
 #    type: redis-persistent:3.2

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -57,8 +57,7 @@ if (isset($relationships['redis'])) {
         ini_set('session.save_handler', 'redis');
         ini_set('session.save_path', sprintf("%s:%d", $endpoint['host'], $endpoint['port']));
     }
-}
-else {
+} else {
 // Store session into /tmp.
     ini_set('session.save_path', '/tmp/sessions');
 }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -40,6 +40,7 @@ if (isset($relationships['rediscache'])) {
         if ($endpoint['scheme'] !== 'memcached') {
             continue;
         }
+
         $container->setParameter('cache_host', $endpoint['host']);
         $container->setParameter('cache_memcached_port', $endpoint['port']);
     }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -47,5 +47,18 @@ if (isset($relationships['cache'])) {
 // Disable PHPStormPass
 $container->setParameter('ezdesign.phpstorm.enabled', false);
 
+// Use Redis-based sessions if possible.
+if (isset($relationships['redis'])) {
+    foreach ($relationships['redis'] as $endpoint) {
+        if ($endpoint['scheme'] !== 'redis') {
+            continue;
+        }
+
+        ini_set('session.save_handler', 'redis');
+        ini_set('session.save_path', sprintf("%s:%d", $endpoint['host'], $endpoint['port']));
+    }
+}
+else {
 // Store session into /tmp.
-ini_set('session.save_path', '/tmp/sessions');
+    ini_set('session.save_path', '/tmp/sessions');
+}

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -34,6 +34,15 @@ if (isset($relationships['rediscache'])) {
         $container->setParameter('cache_host', $endpoint['host']);
         $container->setParameter('cache_redis_port', $endpoint['port']);
     }
+} elseif (isset($relationships['cache'])) {
+    // Fallback to memcached if here (deprecated, we will only handle redis here in the future)
+    foreach ($relationships['cache'] as $endpoint) {
+        if ($endpoint['scheme'] !== 'memcached') {
+            continue;
+        }
+        $container->setParameter('cache_host', $endpoint['host']);
+        $container->setParameter('cache_memcached_port', $endpoint['port']);
+    }
 }
 
 // Use Redis-based sessions if possible. If a separate Redis instance
@@ -46,7 +55,7 @@ if (isset($relationships['redissession'])) {
         }
 
         ini_set('session.save_handler', 'redis');
-        ini_set('session.save_path', sprintf("%s:%d", $endpoint['host'], $endpoint['port']));
+        ini_set('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
 } elseif (isset($relationships['rediscache'])) {
     foreach ($relationships['redissession'] as $endpoint) {
@@ -55,7 +64,7 @@ if (isset($relationships['redissession'])) {
         }
 
         ini_set('session.save_handler', 'redis');
-        ini_set('session.save_path', sprintf("%s:%d", $endpoint['host'], $endpoint['port']));
+        ini_set('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
 
 } else {

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -66,7 +66,6 @@ if (isset($relationships['redissession'])) {
         ini_set('session.save_handler', 'redis');
         ini_set('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
-
 } else {
     // Store session into /tmp.
     ini_set('session.save_path', '/tmp/sessions');

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -48,7 +48,7 @@ if (isset($relationships['redissession'])) {
         ini_set('session.save_handler', 'redis');
         ini_set('session.save_path', sprintf("%s:%d", $endpoint['host'], $endpoint['port']));
     }
-} else if (isset($relationships['rediscache'])) {
+} elseif (isset($relationships['rediscache'])) {
     foreach ($relationships['redissession'] as $endpoint) {
         if ($endpoint['scheme'] !== 'redis') {
             continue;
@@ -59,7 +59,7 @@ if (isset($relationships['redissession'])) {
     }
 
 } else {
-// Store session into /tmp.
+    // Store session into /tmp.
     ini_set('session.save_path', '/tmp/sessions');
 }
 


### PR DESCRIPTION
Enable Redis by default for Platform.sh usage.

* Turn Redis on, ever and always.  There's no compelling reason for someone to not use it on Platform.sh.
* Define a `rediscache` service and endpoint, which will get used for cache if available.
* Optionally define a `redissession` service and endpoint, commented out.  If a particular user desires to use a separate Redis instance they can by uncommenting a few lines.  If not, `rediscache` gets used for sessions as well.
* Remove the Memcache glue code, because we want people to use Redis instead.
* If for some reason Redis is broken, the system will still fall back to disk-based cache and sessions.  But really, try not to do that. :smile: 

This branch once accepted should be forward-ported to 2.x.

I spoke with a member of our support team, and he said there's nothing wrong with having 2 Redis instances (a number of our customers do for various reasons), but we don't know enough about eZ's usage profile to say if it's useful or recommended.  So split the difference for now with an optional toggle.  If we find over time that it really does help in most cases then we can default the separate session store to on very easily.