### PR TITLE
Added symfony/thanks dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "friendsofsymfony/jsrouting-bundle": "^1.4",
         "white-october/pagerfanta-bundle": "^1.1",
         "roave/security-advisories": "dev-master",
-        "leafo/scssphp": "^0.7"
+        "leafo/scssphp": "^0.7",
+        "symfony/thanks": "^1.0"
     },
     "require-dev": {
         "behat/behat": "~3.2",


### PR DESCRIPTION
*This is my first PR to this project. I'm sorry if I did something wrong or not followed some required process.*

I propose to add `symfony/thanks` as a dependency of this project. [Symfony Thanks](https://symfony.com/blog/say-thanks-to-the-libraries-you-depend-on) allows users to say thanks to the libraries used in their projects. Despite its name, it's not a "Symfony thing", but a "PHP thing". It's already been included in Symfony, Laravel ([60de3a5](https://github.com/laravel/laravel/commit/60de3a5670c4a3bf5fb96433828b6aadd7df0e53)), Drupal (via Drupal Console [#3727](https://github.com/hechoendrupal/drupal-console/pull/3727)) and Akeneo PIM ([#7538](https://github.com/akeneo/pim-community-dev/pull/7538)).

Technically speaking, it's a tiny dependency that includes just a few lines of PHP code (all the work is done by Composer) and it doesn't affect the performance in any way (it's just a console command). The dependency doesn't execute anything unless the user explicitly wants to do that and types some command. 

A nice side effect of "saying thanks" is that the entire PHP community gets more recognition on GitHub. That could be the case for eZ too. I personally feel like you deserve many more GitHub stars in all your repos.

Thanks for your consideration!
