### PR TITLE
Disable PHPUnit strict mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "~1.0",
         "ezsystems/behatbundle": "^6.5",
-        "phpunit/phpunit": "^6.4",
+        "phpunit/phpunit": "^6.5",
         "sensio/generator-bundle": "~3.1",
         "symfony/phpunit-bridge": "~3.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          colors="true"
          bootstrap="vendor/autoload.php"
          beStrictAboutTestsThatDoNotTestAnything="false"
+         convertErrorsToExceptions="false"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_CLASS" value="AppKernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="false"
 >
     <php>
         <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
Some tests are failing with upgrade to PHPUnit v6. The reason is strict more, v6 is strict by default. This is also reason why functional rest tests are failing for `ezpublish-kernel`.