### PR TITLE
Fix indentation for the default_ttl config var

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -34,9 +34,9 @@ ezpublish:
             # all eng-GB data to other locales first.
             languages: [eng-GB]
             content:
-              # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
-              # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
-              default_ttl: '%httpcache_default_ttl%'
+                # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
+                # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
+                default_ttl: '%httpcache_default_ttl%'
             # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
             http_cache:
                 purge_servers: ['%purge_server%']


### PR DESCRIPTION
An easy one. Indetation is 4 spaces for all the file except for this part i'm changing now. Just in order to follow the same rule for everything.

ping @andrerom 