### PR TITLE
Wrong number in LimitRequestBody Apache directive

### DIFF
--- a/doc/apache2/Readme.md
+++ b/doc/apache2/Readme.md
@@ -92,7 +92,7 @@ If you do not have an access to use virtualhost config, use the `.htaccess` file
 
     # Set default timeout to 90s, and max upload to 48mb
     TimeOut 90
-    LimitRequestBody 49152
+    LimitRequestBody 50331648
 
     # Disabling MultiViews prevents unwanted negotiation, e.g. "/app" should not resolve
     # to the front controller "/app.php" but be rewritten to "/app.php/app".

--- a/doc/apache2/Readme.md
+++ b/doc/apache2/Readme.md
@@ -43,7 +43,7 @@ Example config for Apache 2.4 in prefork mode:
 
         # Set default timeout to 90s, and max upload to 48mb
         TimeOut 90
-        LimitRequestBody 49152
+        LimitRequestBody 50331648
 
         <Directory /var/www/ezinstall/web>
             Options FollowSymLinks


### PR DESCRIPTION
48MB is 50331648 bytes (in binary) not 49152 bytes. This breaks almost all REST based file uploads.
Ref. to http://httpd.apache.org/docs/2.0/mod/core.html#limitrequestbody