### PR TITLE
Fixed bug: Wrong service loaded when enabling redis session on Platform.sh

### DIFF
--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -69,7 +69,7 @@ if (isset($relationships['rediscache'])) {
         $container->setParameter('cache_dsn', sprintf('%s:%d', $endpoint['host'], $endpoint['port']) . '?retry_interval=3');
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../cache_pool'));
-        $loader->load('cache.memcached.yml');
+        $loader->load('cache.redis.yml');
     }
 } elseif (isset($relationships['cache'])) {
     // Fallback to memcached if here (deprecated, we will only handle redis here in the future)


### PR DESCRIPTION
Fixing merge mistake in https://github.com/ezsystems/ezplatform/commit/5de7218173afc53e7e10d101ed48ba655413d4f0#commitcomment-27718059