### PR TITLE
Redirect /ez route to /admin to help people upgrading 

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -25,3 +25,11 @@ _ezplatformRepositoryFormsRoutes:
 
 fos.js_routing:
     resource: '@FOSJsRoutingBundle/Resources/config/routing/routing.xml'
+
+# Custom redirection from /ez to /admin, feel free to adjust to your needs
+platform1_admin_route:
+    path: /ez
+    controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction
+    defaults:
+        path: /admin
+        permanent: true

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -26,7 +26,7 @@ _ezplatformRepositoryFormsRoutes:
 fos.js_routing:
     resource: '@FOSJsRoutingBundle/Resources/config/routing/routing.xml'
 
-# Custom redirection from /ez to /admin, feel free to adjust to your needs
+# Custom redirection from /ez to /admin, feel free to adjust to your needs or remove if you don't need it
 platform1_admin_route:
     path: /ez
     controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction


### PR DESCRIPTION
And also for people often switching between versions.

I made it only handle root `/ez` as I'm unsure if anything in studio might be using sub routes of `/ez` still in it's current v1 form.