### PR TITLE
Make AppKernel available in console applications global scope

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -26,5 +26,6 @@ if ($debug) {
     Debug::enable();
 }
 
-$application = new Application(new AppKernel($env, $debug));
+$kernel = new AppKernel($env, $debug);
+$application = new Application($kernel);
 $application->run($input);


### PR DESCRIPTION
Symfony by default makes the kernel accessible in the global scope by defining $kernel:
```sh
[user@localhost /scm/blog]# tail bin/console
$kernel = new Kernel($env, $debug);
$application = new Application($kernel);
$application->run($input);
```

The same is done in web/app.php (L26) in ezplatform:
```php
$kernel = new AppKernel($environment, $useDebugging);
```

E.g. you can do the following in web applications:
```php
global $kernel;
$cacheDir = $kernel->getCacheDir();
```

This won't work for console applications because the kernel gets passed directly to new Application():
```php
$application = new Application(new AppKernel($env, $debug));
```

For consistency this should also be possible in console applications.