### PR TITLE
EZP-26238: eZPlatform login screen redirecting to the link the user entered initially

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -21,7 +21,8 @@ security:
             form_login:
                 require_previous_session: false
                 default_target_path: ezplatform.dashboard
-            logout: ~
+            logout:
+                target: ezplatform.dashboard
 
         main:
             anonymous: ~

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -20,6 +20,7 @@ security:
             ezpublish_rest_session: ~
             form_login:
                 require_previous_session: false
+                default_target_path: ezplatform.dashboard
             logout: ~
 
         main:


### PR DESCRIPTION
This brings back default path after login (for /admin/login url) removed in https://github.com/ezsystems/ezplatform-admin-ui/pull/373

https://github.com/ezsystems/ezplatform-ee/pull/75