### PR TITLE
EZP-26491: Remove "Forwarded" header in the VCL to avoid ConflictingHeadersException

### DIFF
--- a/doc/varnish/vcl/varnish3.vcl
+++ b/doc/varnish/vcl/varnish3.vcl
@@ -13,6 +13,10 @@ sub vcl_recv {
     // Advertise Symfony for ESI support
     set req.http.Surrogate-Capability = "abc=ESI/1.0";
 
+    // Varnish, in its default configuration, sends the X-Forwarded-For header but does not filter out Forwarded header
+    // To be removed in Symfony 3.3
+    unset req.http.Forwarded;
+
     // Add a unique header containing the client address (only for master request)
     // Please note that /_fragment URI can change in Symfony configuration
     if (!req.url ~ "^/_fragment") {

--- a/doc/varnish/vcl/varnish4.vcl
+++ b/doc/varnish/vcl/varnish4.vcl
@@ -15,6 +15,10 @@ sub vcl_recv {
     // Advertise Symfony for ESI support
     set req.http.Surrogate-Capability = "abc=ESI/1.0";
 
+    // Varnish, in its default configuration, sends the X-Forwarded-For header but does not filter out Forwarded header
+    // To be removed in Symfony 3.3
+    unset req.http.Forwarded;
+
     // Add a unique header containing the client address (only for master request)
     // Please note that /_fragment URI can change in Symfony configuration
     if (!req.url ~ "^/_fragment") {


### PR DESCRIPTION
> JIRA issue: [EZP-26491](https://jira.ez.no/browse/EZP-26491)

This PR adds the following line: https://github.com/ezsystems/ezplatform/blob/1.13/doc/varnish/vcl/varnish4_xkey.vcl#L31 to our other VCL templates. This is done to avoid ConflictingHeadersException, which is thrown by Symfony when there are both "X-Forwarded-For" and "Forwarded" headers set.
This is also suggested in the Symfony documentation: https://symfony.com/doc/2.8/http_cache/varnish.html#make-symfony-trust-the-reverse-proxy.