### PR TITLE
[Composer] Prefer dist for ez packages to avoid issues with updates.ez.no

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,10 @@
     },
     "config": {
         "process-timeout": 3000,
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "preferred-install": {
+            "ezsystems/*": "dist"
+        }
     },
     "extra": {
         "symfony-app-dir": "app",


### PR DESCRIPTION
From time to time people try to install enterprise and it fails as composer tries to install via source. Latests today was one instance mentioned by @larseirik where someone tried to install 2.1@beta of ee hitting the "could not install from source github.com/..."

As composer by default picks source or dist automatically if user forgets to specify `--prefer-dist` this change will make sure composer prefers dist for eZ packages. See [Composer doc](https://getcomposer.org/doc/06-config.md#preferred-install).

This will *not* solve the same issue if user on purpose, knowingly or not, specifies `--prefer-source`. In that case I think composer will regardlessly pick what the command line user prefers. And as long as we don't have ldap setup to allow partners access to raw source this will not work for people outside of eZ.

**Warning**: I'm so far unsure how this might affect local development for our own engineers/support, as we on the other hands *do* want latests dev for instance over a "out of date" beta or stable release. This might be reason enough to rather try merge this once 2.1 is out, to test it a bit internally before it enters a release.