### PR TITLE
EZP-28950: MySQL UTF8 doesn't support 4-byte chars

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,7 @@ doctrine:
                 dbname: '%database_name%'
                 user: '%database_user%'
                 password: '%database_password%'
-                charset: UTF8
+                charset: utf8mb4
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/app/config/dfs/dfs.yml
+++ b/app/config/dfs/dfs.yml
@@ -9,7 +9,7 @@ doctrine:
                 user: "%dfs_database_user%"
                 password: "%dfs_database_password%"
                 dbname: "%dfs_database_name%"
-                charset: UTF8
+                charset: utf8mb4
 
 # define the flysystem handler
 oneup_flysystem:


### PR DESCRIPTION
> Target version: 2.2
> Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2277

We should use the `utf8mb4` mysql charset which supports all of unicode, instead of `utf8` which does not support 4-byte characters (which includes some Chinese, emojis, and other things).