### PR TITLE
EZP-28962: The OPTIONS REST routes are not loaded anymore

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -13,7 +13,12 @@ kernel.internal:
 
 kernel.rest:
     resource: '@EzPublishRestBundle/Resources/config/routing.yml'
-    prefix: /api/ezp/v2
+    prefix: '%ezpublish_rest.path_prefix%'
+
+kernel.rest.options:
+    resource: '@EzPublishRestBundle/Resources/config/routing.yml'
+    prefix: '%ezpublish_rest.path_prefix%'
+    type: rest_options
 
 ezplatform.admin_ui:
     resource: '@EzPlatformAdminUiBundle/Resources/config/routing.yml'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28962](https://jira.ez.no/browse/EZP-28962)
| **Requires** | ezsystems/ezpublish-kernel#2282
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.1`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

# Description
This definition was missing from v1. It provides `OPTIONS` HTTP method support to REST API.