### PR TITLE
Simplify Platform.sh configuration

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -68,11 +68,7 @@ hooks:
     build: |
         set -e
         rm web/app_dev.php
-        if [ "$SYMFONY_ENV" = "dev" ] ; then
-            composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader
-        else
-            composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
-        fi
+        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
     deploy: |
@@ -83,23 +79,16 @@ hooks:
             php -d memory_limit=-1 bin/console ezplatform:install $INSTALL_EZ_INSTALL_TYPE
             touch web/var/.platform.installed
         fi
-        # When deploying changes to existing cluster, clear all cache now that we have shared mounts available
-        if [ "$SYMFONY_ENV" != "prod" ] ; then
-            # Clear class cache before we boot up symfony in case of interface changes on classes cached
-            rm -Rf var/cache/$SYMFONY_ENV/*.*
-            bin/console cache:clear
-        elif [ -d "var/cache/prod/$PLATFORM_TREE_ID" ] ; then
-            # Clear cache on re-deploy when the folder exits, move folder so post_deploy can cleanup
-            mv -f var/cache/prod/$PLATFORM_TREE_ID var/cache/prod/old_deploy
-        fi
+        # if you re build with the same sha, you still want to clear the cache
+        mv var/cache/$SYMFONY_ENV var/cache/old_deployed_cache 2>/dev/null
+        bin/console cache:clear
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
         ##bin/console kaliop:migration:migrate --no-interaction --no-debug
-    # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     post_deploy: |
         set -e
         # Cleanup old prod cache folders, basically all except current $PLATFORM_TREE_ID folder.
-        find var/cache/prod -mindepth 1 -maxdepth 1 -type d \! \( -name "$PLATFORM_TREE_ID" \) -exec rm -rf '{}' \;
+        find var/cache/$SYMFONY_ENV -mindepth 1 -maxdepth 1 -type d \! \( -name "$PLATFORM_TREE_ID" \) -exec rm -rf '{}' \;
 
 # The configuration of scheduled execution.
 # see http://symfony.com/doc/current/components/console/introduction.html

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -69,27 +69,27 @@ class AppKernel extends Kernel
         return __DIR__;
     }
 
+    private function getSymfonyTempDirPrefix()
+    {
+        return !empty($_SERVER['SYMFONY_TMP_DIR']) ? rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') : dirname(
+            $this->getRootDir()
+        );
+    }
+
     public function getCacheDir()
     {
-        if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
-            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/var/cache/' . $this->getEnvironment();
+        $folder = $this->getSymfonyTempDirPrefix() . '/var/cache/' . $this->getEnvironment();
+
+        if (getenv('PLATFORM_TREE_ID') != '') {
+            return $folder . '/' . getenv('PLATFORM_TREE_ID');
         }
 
-        // On platform.sh place each deployment cache in own folder to rather cleanup old cache async
-        if ($this->getEnvironment() === 'prod' && ($platformTreeId = getenv('PLATFORM_TREE_ID'))) {
-            return dirname(__DIR__) . '/var/cache/prod/' . $platformTreeId;
-        }
-
-        return dirname(__DIR__) . '/var/cache/' . $this->getEnvironment();
+        return $folder;
     }
 
     public function getLogDir()
     {
-        if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
-            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/var/logs';
-        }
-
-        return dirname(__DIR__) . '/var/logs';
+        return $this->getSymfonyTempDirPrefix() . '/var/logs';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)


### PR DESCRIPTION
Hello this PR removes a lot of things, let me explain (and start the discussion)

```diff
-        if [ "$SYMFONY_ENV" = "dev" ] ; then
-            composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader
-        else
-            composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
-        fi
+        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
```
Why would use use Platform.sh in "dev" mode? Even if we could find reason, I don't think we should add this in the `.platform.app.yaml` it complexifies for nothing.

```diff
-        # When deploying changes to existing cluster, clear all cache now that we have shared mounts available
-        if [ "$SYMFONY_ENV" != "prod" ] ; then
-            # Clear class cache before we boot up symfony in case of interface changes on classes cached
-            rm -Rf var/cache/$SYMFONY_ENV/*.*
-            bin/console cache:clear
-        elif [ -d "var/cache/prod/$PLATFORM_TREE_ID" ] ; then
-            # Clear cache on re-deploy when the folder exits, move folder so post_deploy can cleanup
-            mv -f var/cache/prod/$PLATFORM_TREE_ID var/cache/prod/old_deploy
-        fi
+        # if you re build with the same sha, you still want to clear the cache
+        mv var/cache/$SYMFONY_ENV var/cache/old_deployed_cache 2>/dev/null
+        bin/console cache:clear
```

This seems related to https://jira.ez.no/browse/EZEE-1910, where on PE (Platform.sh Enterprise) the mount points are NFS mount points (which is not true in PS)
I think this code is not good, for a common mistake. 
**`cache` and `logs` in multi-node configuration MUST NOT be shared**

Then in PE, things have to be handled differently. We need a cache and a logs folder that are writable but not shared between nodes.

So the correction in EZEE-1910 is a false positive fix, it corrects a situation that should not exist.

We should probably have a `.platform.app.yaml` for PS and one for PE to simplify each of them.


Also about:
```
    ##bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
    ##bin/console kaliop:migration:migrate --no-interaction --no-debug
```

Should we leverage `composer run-scripts` option? to make it better and more abstract to the deployment architecture?

What do you think?

cc @andrerom @vidarl 