### PR TITLE
Fixed typo so session can be stored in rediscache in Platform.sh

### DIFF
--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -103,7 +103,7 @@ if (isset($relationships['redissession'])) {
         $container->setParameter('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
 } elseif (isset($relationships['rediscache'])) {
-    foreach ($relationships['redissession'] as $endpoint) {
+    foreach ($relationships['rediscache'] as $endpoint) {
         if ($endpoint['scheme'] !== 'redis') {
             continue;
         }


### PR DESCRIPTION
Due to this little typo, sessions could only be stored in dedicated redissession service up to this point