### PR TITLE
Platform.sh conf - Real and more useful example of crontab setting

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -105,8 +105,8 @@ hooks:
 # see http://symfony.com/doc/current/components/console/introduction.html
 #crons:
 #    symfony:
-#        spec: "*/20 * * * *"
-#        cmd: "php bin/console ezpublish:cron:run"
+#         spec: "0 0 * * 0"
+#         cmd: "php bin/console ezplatform:check-urls --quiet --env=prod > var/logs/ezp_cron.txt"
 
 runtime:
     extensions:


### PR DESCRIPTION
I propose to replace the cron example by the one that should be activated by default.
If I'm not wrong, the "ezpublish:cron:run" is dedicated to eZ Platform EE only for the Date-based publishing.

Note: I did not find any details on this crontab (check-urls) in the Installation documentation.