### PR TITLE
Use default session handler

### DIFF
--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -1,7 +1,7 @@
 # This file contains defaults for optional parameters, which you can override in parameters.yml
 parameters:
     locale_fallback: en
-    ezplatform.session.handler_id: session.handler.native_file
+    ezplatform.session.handler_id: ~
 
     # A secret key that's used to generate certain security-related tokens
     secret: '%env(SYMFONY_SECRET)%'


### PR DESCRIPTION
Setting the value to the same as in 1.13 branch (https://github.com/ezsystems/ezplatform/blob/1.13/app/config/default_parameters.yml#L4), so that the default session handler will be used.

This is required by our Docker stack: the changes introduced by redis-session container (https://github.com/ezsystems/ezplatform/blob/master/doc/docker/redis-session.yml) have no effect as long as this setting is in place (local value is used instead of master one).