### PR TITLE
[Composer] Bump http cache package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ezsystems/ezplatform-solr-search-engine": "^1.5@dev",
         "ezsystems/platform-ui-bundle": "^1.13@dev",
         "ezsystems/ez-support-tools": "~0.2.1@dev",
-        "ezsystems/ezplatform-http-cache": "^0.4@dev",
+        "ezsystems/ezplatform-http-cache": "~0.6@dev",
         "ezplatform-i18n/ezplatform-i18n-ach_ug": "^1.5@dev",
         "ezsystems/ezplatform-multi-file-upload": "^0.1",
         "ezsystems/ezplatform-design-engine": "^1.1",


### PR DESCRIPTION
To enable several improvements in http cache in 0.5 and 0.6-rc1 and aim to send that to QA as part of 1.13.2 certification.

Todo:
- [x] Verify passing across functional tests here