### PR TITLE
EZP-28868: Enabled eZ Platform Standard Design Bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -39,6 +39,7 @@ class AppKernel extends Kernel
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
             new EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle(),
+            new EzSystems\EzPlatformStandardDesignBundle\EzPlatformStandardDesignBundle(),
             new EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle(),
             new EzSystems\EzPlatformAdminUiModulesBundle\EzPlatformAdminUiModulesBundle(),
             new EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle(),

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -59,3 +59,7 @@ ezpublish:
     url_alias:
         slug_converter:
             transformation: 'urlalias_lowercase'
+
+ez_platform_standard_design:
+    # makes Kernel default templates (in EzPublishCoreBundle/Resources/views) part of standard Design
+    override_kernel_templates: true

--- a/app/config/ezplatform_behat.yml
+++ b/app/config/ezplatform_behat.yml
@@ -13,3 +13,7 @@ ezpublish:
 ezdesign:
     phpstorm:
         enabled: false
+
+ez_platform_standard_design:
+    # for pre eZ Design Engine tests use old template naming
+    override_kernel_templates: false

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "ezsystems/ezplatform-admin-ui-modules": "^1.2@dev",
         "ezsystems/ezplatform-admin-ui-assets": "^3.0@dev",
         "ezsystems/ezplatform-design-engine": "^2.0@dev",
+        "ezsystems/ezplatform-standard-design": "^0.1@dev",
         "ezsystems/ezplatform-cron": "^2.0@dev",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "willdurand/js-translation-bundle": "^2.6.6",


### PR DESCRIPTION
# eZ Platform Standard Design
|      |     |
| --- | --- |
| **JIRA issue** | [EZP-28868](https://jira.ez.no/browse/EZP-28868)
| **Requires** | ~ezsystems/ezplatform-standard-design#2~<br>~ezsystems/ezplatform-standard-design#3~
| **Feature** | yes
| **Bug** | no
| **Doc needed** | yes

This PR enables Standard Design Bundle for eZ Platform `v2.2`.
The Bunde (see PR ezsystems/ezplatform-standard-design#2):
- [x] Defines `standard` design and `standard` theme.
- [x] Maps `EzPublishCoreBundle` views directory to `standard` theme.
- [x] Adds the following Semantic configuration:
  ```yaml
  ez_platform_standard_design:
      # Enable this to prepend Kernel default template paths with @ezdesign namespace
      override_kernel_templates: false
  ```
- [x] If the above setting is set to true - overrides `ezpublish-kernel` SiteAccess-dependend Twig template settings prefixing them with `@ezdesign` namespace:
  - No-layout view (`viewbase_layout.html.twig`).
  - Page Layout (`pagelayout.html.twig`).
  - Full Content view (`default/content/full.html.twig`).
  - Inline Content view (`default/content/line.html.twig`).
  - Linked text Content view (`default/content/text_linked.html.twig`).
  - Embed Content view (`default/content/embed.html.twig`).
  - Embed Image view (`default/content/embed_image.html.twig`).
  - Block view (`default/block/block.html.twig`).
  - Content fields blocks template (`content_fields.html.twig`).
  - Field Def. settings template (`fielddefinition_settings.html.twig`).
- [x] Ensures every design contains `standard` theme as a fallback to properly render the above templates.
- [x] **Rebase after testing disabling of Kernel template overrides.**