### PR TITLE
[Docker] Bump Varnish version to 6.0 for testing

### DIFF
--- a/doc/docker/Dockerfile-varnish
+++ b/doc/docker/Dockerfile-varnish
@@ -3,8 +3,8 @@ FROM debian:stretch-slim
 ENV VARNISH_MALLOC_SIZE="256M" \
     DEBIAN_FRONTEND=noninteractive
 
-ARG PACKAGECLOUD_URL=https://packagecloud.io/install/repositories/varnishcache/varnish5/script.deb.sh
-ARG VARNISH_MODULES_VERSION=0.12.1
+ARG PACKAGECLOUD_URL=https://packagecloud.io/install/repositories/varnishcache/varnish60/script.deb.sh
+ARG VARNISH_MODULES_VERSION=0.15.0
 
 # Use official packages from Varnish and build with varnish-modules mainly for xkey
 # see: https://github.com/varnish/varnish-modules/tree/master/docs


### PR DESCRIPTION
~~Status: varnish-modules 0.14 is not uploaded to download section, and besides from the looks of it there needs to be a new release of it to get it working on Varnish 6.0.~~

~ref: https://github.com/varnish/varnish-modules/issues/113~

Varnish modules 0.15 is out and supports Varnish 6.0, so we can herby bump version _(assuming test pass)_.