### PR TITLE
[Docker] Assuring empty cache in distribution image

### DIFF
--- a/doc/docker/Dockerfile-distribution
+++ b/doc/docker/Dockerfile-distribution
@@ -5,6 +5,8 @@ FROM docker_app as builder
 RUN composer config extra.symfony-assets-install hard
 RUN composer run-script post-install-cmd --no-interaction
 
+RUN rm -Rf /var/www/app/cache/*/*
+
 FROM busybox
 
 COPY --from=builder /var/www /var/www


### PR DESCRIPTION
Environment variables were not taken into account due to pre-generated cache files.
Discovered while running SDC instances of 1.13 branch. Already fixed for 2.x branches (ref. #258)
Affected ezplatform and ezplatform ee

@vidarl and @andrerom for your acceptance