### PR TITLE
[Platform.sh] Move cache to use /tmp instead of NFS to fix slowness on deploy and execution

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -74,7 +74,7 @@ hooks:
             composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         fi
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
-    # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible
+    # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
     deploy: |
         set -e
         # Mainly relevant for eZ Platform demo usage, for own setup adapt this or remove and rely on migrations.
@@ -95,8 +95,9 @@ hooks:
                 mv -f app/cache/prod/$PLATFORM_TREE_ID app/cache/prod/old_deploy
             fi
             # Warmup cache so incomming requests does not need to end up doing that in paralell under load
-            # WARNING: ON NFS this can take quite a bit of time, from 20-50 sec depending of size of project
-            app/console cache:warmup
+            # We do this against /tmp and move it over afterwards in order to do this in under 10s instead of 30-50s
+            SYMFONY_TMP_DIR="/tmp" app/console cache:warmup; unset SYMFONY_TMP_DIR
+            mv /tmp/app/cache/prod/ app/cache/prod/$PLATFORM_TREE_ID
         fi
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##app/console doctrine:migrations:migrate --no-interaction --allow-no-migration

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -8,7 +8,7 @@
 # - PS: Platform.sh Professional
 
 # The name of this app. Must be unique within a project.
-name: app
+name: ez
 
 # The type of the application to build.
 type: php:7.2
@@ -39,8 +39,8 @@ variables:
         # For PE cluster, disable Symfony Proxy & instead use Fastly Bundle available on eZ Platform Enterprise
         #SYMFONY_HTTP_CACHE: 0
         # Place symfony cache on tmpfs to avoid performance issues of having it on NFS, re-deploy to clear cache reliably
-        # "app" comes from application name for platform.sh, so adapt it if you change the name for multi application setups
-        SYMFONY_CACHE_DIR: /tmp/app
+        # "ez" comes from application name for platform.sh, so adapt it if you change the name for multi application setups
+        SYMFONY_CACHE_DIR: /tmp/ez
         # PS: Given we just set cache directory to be non shared, we need to make sure http cache is shared (ignored when using Fastly)
         SYMFONY_HTTP_CACHE_DIR: app/cache/prod
         # Change this to dev if you want to run site & commands in dev
@@ -84,27 +84,27 @@ hooks:
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
     deploy: |
         set -e
-        # Mainly relevant for eZ Platform demo usage, for own setup adapt this or remove and rely on migrations.
+        # Mainly relevant for eZ Platform demo usage, for own setup adapt this, or remove and rely on migrations.
         if [ ! -f web/var/.platform.installed ]; then
             . ./.env
             php -d memory_limit=-1 app/console ezplatform:install $INSTALL_EZ_INSTALL_TYPE
             touch web/var/.platform.installed
         fi
-        # Clear class cache before we boot up symfony in case of interface changes on classes cached
-        rm -Rf $SYMFONY_CACHE_DIR/app/cache/
-        # Clear cache AND maybe more im warmup
-        app/console cache:clear
+        # Clear class/lazy-proxy cache before we boot up symfony in case of interface changes on classes cached
+        rm -Rf $SYMFONY_CACHE_DIR/app/cache/$SYMFONY_ENV/*.*
+        # Clear cache, but leave warmup to be done on-demand and per node at startup (web.commands.start)
+        app/console cache:clear --no-warmup
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##app/console doctrine:migrations:migrate --no-interaction --allow-no-migration
         ##app/console kaliop:migration:migrate --no-interaction --no-debug
-        # At this point should detect if any of the migrations did changes, if so: clear redis cache + exire Http cache
+        # If migration changes happened and they did not use API, then: clear redis cache & exire Http cache
 
 # Given we place cache per node we opt to warmup cache before letting requests hit them, NOTE:
-# 1. Adapt this if you change php version, 2. For PE setups, open support ticket to platform.sh for adapting changes
-# https://docs.platform.sh/languages/php.html#alternate-start-commands
+# 1. Adapt this if you change php version*, 2. For PE setups, open support ticket to platform.sh for adapting changes
+# * https://docs.platform.sh/languages/php.html#alternate-start-commands
 web:
     commands:
-        start: 'app/console cache:warmup && /usr/sbin/php-fpm7.1-zts'
+        start: 'app/console cache:warmup && /usr/sbin/php-fpm7.2-zts'
 
 
 # The configuration of scheduled execution.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -74,7 +74,7 @@ hooks:
             composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         fi
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
-    # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
+    # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible
     deploy: |
         set -e
         # Mainly relevant for eZ Platform demo usage, for own setup adapt this or remove and rely on migrations.
@@ -87,10 +87,16 @@ hooks:
         if [ "$SYMFONY_ENV" != "prod" ] ; then
             # Clear class cache before we boot up symfony in case of interface changes on classes cached
             rm -Rf app/cache/$SYMFONY_ENV/*.*
+            # Clear cache and warmup
             app/console cache:clear
-        elif [ -d "app/cache/prod/$PLATFORM_TREE_ID" ] ; then
-            # Clear cache on re-deploy when the folder exits, move folder so post_deploy can cleanup
-            mv -f app/cache/prod/$PLATFORM_TREE_ID app/cache/prod/old_deploy
+        else
+            # For prod we have a clean folder on each deploy, if re-deploying a sha we move & let post_deploy clean up
+            if [ -d "app/cache/prod/$PLATFORM_TREE_ID" ] ; then
+                mv -f app/cache/prod/$PLATFORM_TREE_ID app/cache/prod/old_deploy
+            fi
+            # Warmup cache so incomming requests does not need to end up doing that in paralell under load
+            # WARNING: ON NFS this can take quite a bit of time, from 20-50 sec depending of size of project
+            app/console cache:warmup
         fi
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##app/console doctrine:migrations:migrate --no-interaction --allow-no-migration

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -2,7 +2,10 @@
 # in the same project.
 
 # Please see doc/platformsh/README.md and doc/platformsh/INSTALL.md
-# NB: Clustered eZ Platform setups are not tested and are likely to have issues.
+
+# Vocabulary:
+# - PE: Platform.sh Enterprise
+# - PS: Platform.sh Professional
 
 # The name of this app. Must be unique within a project.
 name: app
@@ -33,8 +36,13 @@ variables:
         # Example of setting php.ini config
         #"display_errors": "On"
     env:
-        # For enterprise cluster, disable Symfony Proxy & instead use Fastly Bundle available on eZ Platform Enterprise
+        # For PE cluster, disable Symfony Proxy & instead use Fastly Bundle available on eZ Platform Enterprise
         #SYMFONY_HTTP_CACHE: 0
+        # Place symfony cache on tmpfs to avoid performance issues of having it on NFS, re-deploy to clear cache reliably
+        # "app" comes from application name for platform.sh, so adapt it if you change the name for multi application setups
+        SYMFONY_CACHE_DIR: /tmp/app
+        # PS: Given we just set cache directory to be non shared, we need to make sure http cache is shared (ignored when using Fastly)
+        SYMFONY_HTTP_CACHE_DIR: app/cache/prod
         # Change this to dev if you want to run site & commands in dev
         SYMFONY_ENV: prod
         # Uncomment if you want to use DFS clustering:
@@ -56,7 +64,6 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "/app/cache": "shared:files/cache"
     "/app/logs": "shared:files/logs"
     "/web/var": "shared:files/files"
     # Uncomment if you want to use DFS clustering:
@@ -73,7 +80,7 @@ hooks:
         else
             composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         fi
-    # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
+    # Deploy hook, access to services & done once (per cluster, not per node), only mounts & tmpfs are writable at this point
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
     deploy: |
         set -e
@@ -83,30 +90,22 @@ hooks:
             php -d memory_limit=-1 app/console ezplatform:install $INSTALL_EZ_INSTALL_TYPE
             touch web/var/.platform.installed
         fi
-        # When deploying changes to existing cluster, clear all cache now that we have shared mounts available
-        if [ "$SYMFONY_ENV" != "prod" ] ; then
-            # Clear class cache before we boot up symfony in case of interface changes on classes cached
-            rm -Rf app/cache/$SYMFONY_ENV/*.*
-            # Clear cache and warmup
-            app/console cache:clear
-        else
-            # For prod we have a clean folder on each deploy, if re-deploying a sha we move & let post_deploy clean up
-            if [ -d "app/cache/prod/$PLATFORM_TREE_ID" ] ; then
-                mv -f app/cache/prod/$PLATFORM_TREE_ID app/cache/prod/old_deploy
-            fi
-            # Warmup cache so incomming requests does not need to end up doing that in paralell under load
-            # We do this against /tmp and move it over afterwards in order to do this in under 10s instead of 30-50s
-            SYMFONY_TMP_DIR="/tmp" app/console cache:warmup; unset SYMFONY_TMP_DIR
-            mv /tmp/app/cache/prod/ app/cache/prod/$PLATFORM_TREE_ID
-        fi
+        # Clear class cache before we boot up symfony in case of interface changes on classes cached
+        rm -Rf $SYMFONY_CACHE_DIR/app/cache/
+        # Clear cache AND maybe more im warmup
+        app/console cache:clear
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##app/console doctrine:migrations:migrate --no-interaction --allow-no-migration
         ##app/console kaliop:migration:migrate --no-interaction --no-debug
-    # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
-    post_deploy: |
-        set -e
-        # Cleanup old prod cache folders, basically all except current $PLATFORM_TREE_ID folder.
-        find app/cache/prod -mindepth 1 -maxdepth 1 -type d \! \( -name "$PLATFORM_TREE_ID" \) -exec rm -rf '{}' \;
+        # At this point should detect if any of the migrations did changes, if so: clear redis cache + exire Http cache
+
+# Given we place cache per node we opt to warmup cache before letting requests hit them, NOTE:
+# 1. Adapt this if you change php version, 2. For PE setups, open support ticket to platform.sh for adapting changes
+# https://docs.platform.sh/languages/php.html#alternate-start-commands
+web:
+    commands:
+        start: 'app/console cache:warmup && /usr/sbin/php-fpm7.1-zts'
+
 
 # The configuration of scheduled execution.
 # see http://symfony.com/doc/current/components/console/introduction.html

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,6 +1,6 @@
 "https://{default}/":
     type: upstream
-    upstream: "app:http"
+    upstream: "ez:http"
     cache:
         # As this does not support Vary, and purging, we can't use this as Sf Proxy drop in.
         # However it is possible to enable this for anonymous traffic when backend sends expiry headers.

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -69,6 +69,10 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
+        if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
+            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/app/cache/' . $this->getEnvironment();
+        }
+
         // On platform.sh place each deployment cache in own folder to rather cleanup old cache async
         if ($this->getEnvironment() === 'prod' && ($platformTreeId = getenv('PLATFORM_TREE_ID'))) {
             return "{$this->getRootDir()}/cache/{$this->getEnvironment()}/{$platformTreeId}";

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -69,13 +69,8 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        if (!empty($_SERVER['SYMFONY_TMP_DIR'])) {
-            return rtrim($_SERVER['SYMFONY_TMP_DIR'], '/') . '/app/cache/' . $this->getEnvironment();
-        }
-
-        // On platform.sh place each deployment cache in own folder to rather cleanup old cache async
-        if ($this->getEnvironment() === 'prod' && ($platformTreeId = getenv('PLATFORM_TREE_ID'))) {
-            return "{$this->getRootDir()}/cache/{$this->getEnvironment()}/{$platformTreeId}";
+        if (!empty($_SERVER['SYMFONY_CACHE_DIR'])) {
+            return rtrim($_SERVER['SYMFONY_CACHE_DIR'], '/') . '/app/cache/' . $this->getEnvironment();
         }
 
         return parent::getCacheDir();

--- a/doc/platformsh/README.md
+++ b/doc/platformsh/README.md
@@ -6,8 +6,9 @@
 *Platform.sh* is a continuous deployment cloud hosting solution which can replicate a live production setup in seconds and create byte-level clones of throwaway dev and staging environments, which makes human testing and validation easy.
 
 ## Current limitations
-- Clustering is not yet tested or supported.
-- Performance is limited, as installation instructions do not yet cover any particular CDN or HTTP caching tools like Varnish or Fastly.
+- Configuration is limited to eZ Platform 1.13 and higher setups, if you intend to run legacy bridge or pure eZ Publish legacy on platform.sh
+  you should ideally get in contact with a eZ Partner who has experience with this already, possible also get some consulting hours
+  by eZ Professional Services to help on your migration path.
 
 ## Install
 For installation instructions, see [INSTALL.md](https://github.com/ezsystems/ezplatform/blob/master/doc/platformsh/INSTALL.md).

--- a/web/app.php
+++ b/web/app.php
@@ -40,20 +40,22 @@ if (!$useDebugging && PHP_VERSION_ID < 70000) {
     $kernel->loadClassCache();
 }
 
-// Depending on the SYMFONY_HTTP_CACHE environment variable, tells whether the internal HTTP Cache mechanism is to be used.
+// Depending on the SYMFONY_HTTP_CACHE environment variable, tells whether Symfony internal HTTP Proxy Cache is to be used.
 // If not set, or "", it is auto activated if _not_ in "dev" environment.
 if (($useHttpCache = getenv('SYMFONY_HTTP_CACHE')) === false || $useHttpCache === '') {
     $useHttpCache = $environment !== 'dev';
 }
 
-// Load HTTP Cache ...
+// Load Symfony's Proxy for HTTP Cache (should not be used when using Varnish or Fastly)
 if ($useHttpCache) {
     // The standard HttpCache implementation can be overridden by setting the SYMFONY_HTTP_CACHE_CLASS environment variable.
     // NOTE: Make sure to setup composer config so it is *autoloadable*, or use "SYMFONY_CLASSLOADER_FILE" for this.
+    // SYMFONY_HTTP_CACHE_DIR is optional env variable for having different directory for Symfony's Http Cache Proxy
+    $httpCacheDir = getenv('SYMFONY_HTTP_CACHE_DIR');
     if ($httpCacheClass = getenv('SYMFONY_HTTP_CACHE_CLASS')) {
-        $kernel = new $httpCacheClass($kernel);
+        $kernel = new $httpCacheClass($kernel, $cacheDir ?: null);
     } else {
-        $kernel = new AppCache($kernel);
+        $kernel = new AppCache($kernel, $cacheDir ?: null);
     }
 }
 


### PR DESCRIPTION
~This is not solving issues with cache warmup taking a long time on NFS, however it makes sure it is done during deploy so incomming requests don't end up competing to create it.~

~So while this slows down deploy, in practice should make the app response quicker and more stable* once it start accepting requests again.~

Makes sure to warmup cache so requests coming in after deploy doesn't need to fight for it. Also does that to `/tmp` dir to make sure it can run fast as it needs to write many small files _(was taking 30-50s on NFS..)_. Afterwards we move the directory over to NFS mount.

The changes in AppKernel is backport from v2, we could also backport this for log directory, see: https://github.com/ezsystems/ezplatform/blob/master/app/AppKernel.php#L72-L93

\* _There have been reports on 503s happing on the first response being let in once site is back up, could be related all incomming requests needing to generate cache, but can also be related to custom stuff done on the given install._

Todo:
- [x] Set cache folder to /tmp during cache warmup and move files over in bulk once done
- [ ] Rebase and cleanup once varnish work has been merged