### PR TITLE
EZP-29167: Set lowercase URL aliases as the default configuration

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -55,3 +55,7 @@ ezpublish:
                 default_ttl: '%httpcache_default_ttl%'
             http_cache:
                 purge_servers: ['%purge_server%']
+
+    url_alias:
+        slug_converter:
+            transformation: 'urlalias_lowercase'


### PR DESCRIPTION
|      |     |
| --- | --- |
| **JIRA issue** | [EZP-29167](https://jira.ez.no/browse/EZP-29167) |
| **Related PR** | ezsystems/ezpublish-kernel#2346 |
| **Bug/Improvement**| no
| **New feature**    | yes
| **BC breaks**      | no

There is a demand for a generated URL aliases to be by default lowercase, which is more SEO-friendly behavior.

To keep BC for users that updated their installation, we've decided to change this default setting here, in the meta-repository.

This allows Kernel to behave in a BC way and achieve the goal for new installations.
Users updating their eZ Platform version will need to adjust that setting to their needs.

**TODO**:
- [x] Add default URL alias Slug Converter transformation configuration to `app/config/ezplatform.yml`.
- [x] Ask for Code Review.