### PR TITLE
[Doc] Update Apache vhost examples to have one fully working for 2.4

### DIFF
--- a/bin/vhost.sh
+++ b/bin/vhost.sh
@@ -95,8 +95,8 @@ Arguments:
   [--sf-trusted-proxies=127.0.0.1,....]    : Comma separated trusted proxies (e.g. Varnish), that we can get client ip from
   [--sf-http-cache=0|1]                    : To disable Symfony HTTP cache Proxy for using a different reverse proxy
                                              By default disabled when evn is "dev", enabled otherwise.
-  [--sf-http-cache-class=<class-file.php>] : To specify a different class then default to use as the Symfony proxy
-  [--sf-classloader-file=<class-file.php>] : To specify a different class then default to use for PHP auto loading
+  [--sf-http-cache-class=<class-file.php>] : DEPRECATED - To specify a different class then default to use as the Symfony proxy
+  [--sf-classloader-file=<class-file.php>] : DEPRECATED - To specify a different class then default to use for PHP auto loading
   [--body-size-limit=<int>]                : Limit in megabytes for max size of request body, 0 value disables limit.
   [--request-timeout=<int>]                : Limit in seconds before timeout of request, 0 value disables timeout limit.
   [--binary-data-handler=dfs|]             : Name of handler in user. Specify "dfs" if you are using the dfs io handler.
@@ -272,6 +272,9 @@ while [  "${template_vars[$COUNTER]}" != "" ]; do
             fi
         done
     else
+        # Change "#if[!VAR] " comments conditionally to uncommented lines
+        tmp=${tmp//"#if[!${current_var}] "/""}
+
         # Change #if[VARIABLE[...]] comments to conventional comment lines
         regex="if\[${current_var}([^]]*)\] "
         while [[ $tmp =~ $regex ]] ; do

--- a/doc/apache2/Readme.md
+++ b/doc/apache2/Readme.md
@@ -67,13 +67,13 @@ Example config for Apache 2.4 in prefork mode:
         # Access to repository images in single server setup
         RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* - [L]
 
-        # Makes it possible to place your favicon at the root `web` directory in your eZ instance.
-        # It will then be served directly.
+        # Makes it possible to placed your favicon and robots.txt at the root of your web folder
         RewriteRule ^/favicon\.ico - [L]
         RewriteRule ^/robots\.txt - [L]
 
-        # The following rule is needed to correctly display assets from eZ / Symfony bundles
+        # The following rules are needed to correctly display bundle and project assets
         RewriteRule ^/bundles/ - [L]
+        RewriteRule ^/assets/ - [L]
 
         # Additional Assetic rules for environments different from dev,
         # remember to run php app/console assetic:dump --env=prod
@@ -133,11 +133,14 @@ If you do not have an access to use virtualhost config, use the `.htaccess` file
 
 Virtual host template
 ---------------------
-This folder contains `vhost.template` file which provides more features you can enable in your virtual host configuration. You may also use this file as a `.htaccess` config. However, you will need to adjust rewrite rules to remove `/` like in the example above.
+This folder contains `vhost.template` for Apache 2.4, and `vhost.2.2.template` for Apache 2.2, both which provides more
+features you can enable in your virtual host configuration. You may also use this file as a `.htaccess` config. However,
+you will need to adjust rewrite rules to remove `/` like in the example above.
 
 *Note: vhost.template uses `mod_setenvif`, adapt it as indicated inline if you can't install it.*
 
-Bash script *(Unix/Linux/OS X)* exists to be able to generate the configuration. To display help text, execute the following from the eZ installation root:
+Bash script *(Unix/Linux/OS X)* exists to be able to generate the configuration. To display help text, execute the
+following from the eZ installation root:
 ```bash
 ./bin/vhost.sh -h
 ```

--- a/doc/apache2/vhost.2.2.template
+++ b/doc/apache2/vhost.2.2.template
@@ -1,4 +1,5 @@
-# Official VirtualHost configuration for Apache 2.4 template
+# Official VirtualHost configuration for Apache 2.2. template
+## Deprecated, please plan your move to Apache 2.4 or Nginx
 # See Readme.md for how to generate your config manually, or in automated deployments.
 # Note: This is meant to be manually tailored for your needs, expires headers might for instance not work for your dev setup.
 
@@ -21,23 +22,11 @@
 
     # "web" folder is what we expose to the world, all rewrite rules further down is relative to it.
     <Directory %BASEDIR%/web>
-        <FilesMatch \.php$>
-            # For serving php files configure mod_proxy to talk to php-fpm using Apache 2.4.10 and higher.
-            # See: https://wiki.apache.org/httpd/PHP-FPM#apache_httpd_2.4
-
-            # For best performance, prefer socket use. This requires Linux, and that both Apache and PHP has access to
-            # the socket file `/var/run/php5-fpm.sock` via local file system and hence run on the same machine.
-            #SetHandler "proxy:unix:/var/run/php5-fpm.sock|fcgi://localhost/"
-            # For TCP usage, if you're not on Linux, or Apache and PHP are on separate machines, instead use fcgi: form.
-            # (Optionally hint php-fpm processes count using: https://wiki.apache.org/httpd/PHP-FPM#Proxy_via_handler)
-            #SetHandler "proxy:fcgi://localhost/:9000"
-
-            SetHandler "proxy:%FASTCGI_PASS%|fcgi://localhost/"
-        </FilesMatch>
-
+        # If using php configured in FastCGI mode, you might also need to add "ExecCGI" to the line below
         Options FollowSymLinks
         AllowOverride None
-        Require all granted
+        # Depending on your global Apache settings, you may need to uncomment and adapt:
+        #Allow from all
     </Directory>
 
     ## eZ Platform/Symfony ENVIRONMENT variables, for customizing app.php* execution

--- a/doc/apache2/vhost.2.2.template
+++ b/doc/apache2/vhost.2.2.template
@@ -40,7 +40,7 @@
     # Optional: Whether to use debugging.
     # Possible values: 0, 1 or ""
     # Defaults to enabled if SYMFONY_ENV is set to "dev" if env value is omitted or empty
-    #if[SYMFONY_DEBUG] SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"s
+    #if[SYMFONY_DEBUG] SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"
 
     # Optional: Whether to use custom ClassLoader (autoloader) file
     # Needs to be a valid path relative to root web/ directory

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -51,7 +51,7 @@
     # Optional: Whether to use debugging.
     # Possible values: 0, 1 or ""
     # Defaults to enabled if SYMFONY_ENV is set to "dev" if env value is omitted or empty
-    #if[SYMFONY_DEBUG] SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"s
+    #if[SYMFONY_DEBUG] SetEnv SYMFONY_DEBUG "%SYMFONY_DEBUG%"
 
     # Optional: Whether to use custom ClassLoader (autoloader) file
     # Needs to be a valid path relative to root web/ directory


### PR DESCRIPTION
Needed to unblock https://github.com/ezsystems/developer-documentation/pull/269


Optional followup:
- Add/use Apache docker image to see if we can have some of the test runs using apache instead of Nginx