### PR TITLE
EZP-29324: Upgrade to MariaDB 10.2 (+PHP 7.2) for eZ Platform Cloud

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -8,7 +8,7 @@
 name: app
 
 # The type of the application to build.
-type: php:7.1
+type: php:7.2
 build:
     # "none" means we're running composer manually, see build hook
     flavor: "none"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,5 +1,6 @@
 mysqldb:
     type: mysql:10.2
+    # Version 10.1 might be a better option when running Legacy Bridge
     disk: 2048
     configuration:
         schemas:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,6 +1,7 @@
 mysqldb:
     type: mysql:10.2
     # Version 10.1 might be a better option when running Legacy Bridge
+    # For more information see https://doc.ezplatform.com/en/2.1/getting_started/requirements_and_system_configuration/#supported-setups
     disk: 2048
     configuration:
         schemas:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,5 +1,5 @@
 mysqldb:
-    type: mysql:10.1
+    type: mysql:10.2
     disk: 2048
     configuration:
         schemas:


### PR DESCRIPTION
The MySQL column sizes limited installation to Platform.sh infrastructure with the previous setting of the database (MariaDB 10.1). This PR upgrades the MariaDB version to 10.2. Unrelated to this - It also bumps PHP to 7.2 by default (was 7.1) for improved performance and features.

NOTE: These changes should also be applied to the following repositories:

 - https://github.com/ezsystems/ezplatform-ee
 - https://github.com/ezsystems/ezplatform-ee-demo
 - https://github.com/ezsystems/ezplatform-demo