### PR TITLE
[Composer] Simplified the command to install eZ Platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,9 @@
         ],
         "post-create-project-cmd": [
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
+        ],
+        "ezplatform-install": [
+            "@php bin/console ezplatform:install clean"
         ]
     },
     "config": {


### PR DESCRIPTION
Some time ago @damianz5 introduced to our Enterprise Edition demo a composer command which was the wrapper for `ezplatform:install <type>` command. We've tested that there and it's been proven to be a great simplification.

This PR introduces the same command wrapper:
```bash
composer ezplatform-install
```
but using `clean` type for open source version of eZ Platform. The idea is to adjust it when merging from this upstream to other meta-repositories by setting a proper install `<type>`.

Justification for that is the fact that every meta-repository (`ezplatform`, `ezplatform-demo`, `ezplatform-ee`, `ezplatform-ee-demo`) uses its own installer type and there is no point to use a different one (e.g. demo sites will crash when clean one is used).