### PR TITLE
EZP-29388: Not possible to set session handler via docker

### DIFF
--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -81,3 +81,11 @@ if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
 if ($value = getenv('PUBLIC_SERVER_URI')) {
     $container->setParameter('ez_recommendation.default.server_uri', $value);
 }
+
+if ($value = getenv('SESSION_HANDLER_ID')) {
+    $container->setParameter('ezplatform.session.handler_id', $value);
+}
+
+if ($value = getenv('SESSION_SAVE_PATH')) {
+    $container->setParameter('session.save_path', $value);
+}

--- a/doc/docker/redis-session.yml
+++ b/doc/docker/redis-session.yml
@@ -10,8 +10,8 @@ services:
     depends_on:
      - redis-session
     environment:
-     - PHP_INI_ENV_session.save_handler=redis
-     - PHP_INI_ENV_session.save_path="tcp://redis-session:6379?weight=1"
+     - SESSION_HANDLER_ID=ezplatform.core.session.handler.native_redis
+     - SESSION_SAVE_PATH=tcp://redis-session:6379?weight=1
 
   redis-session:
     image: ${REDIS_IMAGE}


### PR DESCRIPTION
This one fixes [EZP-29388](https://jira.ez.no/browse/EZP-29388)

In symfony 3, default session_handler is set to [handler_id:  session.handler.native_file](https://github.com/symfony/symfony-standard/pull/904).

That means that it is not possible to override session handler in php.ini without changing config back to `handler_id:  ~`

Therefore, in this PR we inject session handler using environment variable

If accepted, this PR replaces https://github.com/ezsystems/ezplatform/pull/284