### PR TITLE
Fix session save_path

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,7 +66,7 @@ framework:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         # handler_id set to null will use default session handler from php.ini
         handler_id: '%ezplatform.session.handler_id%'
-        save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+        save_path: '%session.save_path%'
         # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by
         #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
         #       Further reading on sessions: http://doc.ezplatform.com/en/master/guide/sessions/

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,7 +66,7 @@ framework:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         # handler_id set to null will use default session handler from php.ini
         handler_id: '%ezplatform.session.handler_id%'
-        save_path: '%session.save_path%'
+        save_path: '%ezplatform.session.save_path%'
         # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by
         #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
         #       Further reading on sessions: http://doc.ezplatform.com/en/master/guide/sessions/

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -2,7 +2,7 @@
 parameters:
     locale_fallback: en
     ezplatform.session.handler_id: session.handler.native_file
-    session.save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+    ezplatform.session.save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
 
     # A secret key that's used to generate certain security-related tokens
     secret: '%env(SYMFONY_SECRET)%'

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -2,6 +2,7 @@
 parameters:
     locale_fallback: en
     ezplatform.session.handler_id: session.handler.native_file
+    session.save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
 
     # A secret key that's used to generate certain security-related tokens
     secret: '%env(SYMFONY_SECRET)%'

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -87,5 +87,5 @@ if ($value = getenv('SESSION_HANDLER_ID')) {
 }
 
 if ($value = getenv('SESSION_SAVE_PATH')) {
-    $container->setParameter('session.save_path', $value);
+    $container->setParameter('ezplatform.session.save_path', $value);
 }


### PR DESCRIPTION
Currently the session save_path is set to use the filesystem by default. When trying to use redis the session save_path string would need to be modified. There is check for a env var in generic.php that sets the session.save_path variable however it isn't being used in the config.yml and continues to save to the filesystem instead of redis.