### PR TITLE
Fix usage of session env variables and move some over to use env()

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,12 +64,12 @@ framework:
     trusted_hosts: ~
     session:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
-        # handler_id set to null will use default session handler from php.ini
-        handler_id: '%ezplatform.session.handler_id%'
-        save_path: '%ezplatform.session.save_path%'
-        # Note: eZ Publish also allows session name and session cookie configuration to be per SiteAccess, by
+        # if handler_id set to null will use default session handler from php.ini
+        handler_id: '%session.handler_id%'
+        save_path: '%session.save_path%'
+        # Note: eZ Platform also allows session name and session cookie configuration to be per SiteAccess, by
         #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
-        #       Further reading on sessions: http://doc.ezplatform.com/en/master/guide/sessions/
+        #       Further reading on sessions: http://doc.ezplatform.com/en/latest/guide/sessions/
     fragments: ~
     http_method_override: true
     assets: true

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -96,7 +96,7 @@ parameters:
     purge_type: local
 
     ## Session handler, by default set to file based in order to be able to use %session.save_path%
-    # evn: SESSION_HANDLER_ID
+    # env: SESSION_HANDLER_ID
     session.handler_id: session.handler.native_file
 
     # Admin siteaccess group name

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -1,8 +1,6 @@
 # This file contains defaults for optional parameters, which you can override in parameters.yml
 parameters:
     locale_fallback: en
-    ezplatform.session.handler_id: session.handler.native_file
-    ezplatform.session.save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
 
     # A secret key that's used to generate certain security-related tokens
     secret: '%env(SYMFONY_SECRET)%'
@@ -45,6 +43,14 @@ parameters:
     # using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
     httpcache_default_ttl: '%env(HTTPCACHE_DEFAULT_TTL)%'
 
+    # Session save path as used by symfony session handlers (eg. used for dsn with redis)
+    session.save_path: '%env(SESSION_SAVE_PATH)%'
+
+    # Recommendation Bundle params
+    ez_recommendation.default.yoochoose.customer_id: '%env(RECOMMENDATIONS_CUSTOMER_ID)%'
+    ez_recommendation.default.yoochoose.license_key: '%env(RECOMMENDATIONS_LICENSE_KEY)%'
+    ez_recommendation.default.server_uri: '%env(PUBLIC_SERVER_URI)%'
+
     # Fallback values for when environment variables do not exist
 
     env(MAILER_HOST):       127.0.0.1
@@ -66,19 +72,32 @@ parameters:
 
     env(HTTPCACHE_DEFAULT_TTL): 86400
 
+    env(SESSION_SAVE_PATH): '%kernel.project_dir%/var/sessions/%kernel.environment%'
+
+    env(RECOMMENDATIONS_CUSTOMER_ID):   ~
+    env(RECOMMENDATIONS_LICENSE_KEY):   ~
+    env(PUBLIC_SERVER_URI):             ~
+
 
     # Compile time handlers
     ## These are defined at compile time, and hence can't be set at runtime using env()
     ## app/config/env/generic.php takes care about letting you set them by env variables
 
     ## Log type is one of "stream", "error_log" or other types supported by monolog
+    # env: LOG_TYPE
     log_type: stream
 
     ## Mail transport used by SwiftMailer
+    # env: MAILER_TRANSPORT
     mailer_transport:  smtp
 
-    # Purge type used by HttpCache system ("local", "varnish"/"http", and on ee also "fastly")
+    ## Purge type used by HttpCache system ("local", "varnish"/"http", and on ee also "fastly")
+    # env: HTTPCACHE_PURGE_TYPE
     purge_type: local
+
+    ## Session handler, by default set to file based in order to be able to use %session.save_path%
+    # evn: SESSION_HANDLER_ID
+    session.handler_id: session.handler.native_file
 
     # Admin siteaccess group name
     admin_group_name: admin_group

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -68,24 +68,6 @@ if ($value = getenv('LOG_TYPE')) {
     $container->setParameter('log_type', $value);
 }
 
-// EzSystemsRecommendationsBundle settings
-// @todo Move to use env() and params
-if ($value = getenv('RECOMMENDATIONS_CUSTOMER_ID')) {
-    $container->setParameter('ez_recommendation.default.yoochoose.customer_id', $value);
-}
-
-if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
-    $container->setParameter('ez_recommendation.default.yoochoose.license_key', $value);
-}
-
-if ($value = getenv('PUBLIC_SERVER_URI')) {
-    $container->setParameter('ez_recommendation.default.server_uri', $value);
-}
-
 if ($value = getenv('SESSION_HANDLER_ID')) {
-    $container->setParameter('ezplatform.session.handler_id', $value);
-}
-
-if ($value = getenv('SESSION_SAVE_PATH')) {
-    $container->setParameter('ezplatform.session.save_path', $value);
+    $container->setParameter('session.handler_id', $value);
 }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -104,7 +104,7 @@ if (isset($relationships['redissession'])) {
             continue;
         }
 
-        $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+        $container->setParameter('session.handler_id', 'ezplatform.core.session.handler.native_redis');
         $container->setParameter('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
 } elseif (isset($relationships['rediscache'])) {
@@ -113,7 +113,7 @@ if (isset($relationships['redissession'])) {
             continue;
         }
 
-        $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+        $container->setParameter('session.handler_id', 'ezplatform.core.session.handler.native_redis');
         $container->setParameter('session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
     }
 }

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,7 +1,11 @@
 # This file is a "template" of what your parameters.yml file should look like
+#
+# NB!: Some parameters are on purpose placed in default_parameters.yml to not
+#      prompt on all possible parameters during install with no info to go with it.
+#      (This will change once we move to use Symfony flex)
 parameters:
     # A secret key that's used to generate certain security-related tokens
-    env(SYMFONY_SECRET): ThisEzPlatformTokenIsNotSoSecretChangeIt
+    env(SYMFONY_SECRET): ThisEzPlatformTokenIsNotSoSecret_PleaseChangeIt
 
     # Settings for database backend used by Doctrine DBAL
     # In turn used for default storage engine & default search engine (if legacy is configured as search engine)


### PR DESCRIPTION
Some further cleanup on session env variables, and move some non handler based params to use `env()` and hence fix inline todo.

Besides cleanup, this fixes that platformsh.php was setting wrong session.save_path parameter.

This is followup to #307 (done in 2.2-dev) and #304
It also tries to clarify a bit the confusion in #306

review ping @alongosz, @raupie, @Plopix 