### PR TITLE
EZP-29455: Prepare regression setup with default configuration

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ COMPOSE_DIR=.
 
 # You'll need to adjust this for Windows and XDB Linux systems: https://getcomposer.org/doc/03-cli.md#composer-home
 COMPOSER_HOME=~/.composer
+COMPOSER_MEMORY_LIMIT=2G
 DATABASE_USER=ezp
 DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,17 @@ env:
     - TEST_CMD="bin/behat -vv --profile=rest --suite=fullXml --tags=~@broken"
     - TEST_CMD="bin/behat -vv --profile=core --tags=~@broken"
     - TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
-    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
+
 
 # test only master (+ Pull requests)
 branches:
   only:
     - master
     - /^\d.\d+$/
+    # build tags (vX.Y.Z)
+    - /^v\d+.\d+.\d+$/
 
 # Update Docker and Docker Compose
 before_install: ./bin/.travis/trusty/update_docker.sh
@@ -53,9 +57,14 @@ after_failure:
   # Will show us what is up, and how long it's been up
   - docker ps -s
 
-# disable mail notifications
 notifications:
-  email: false
+  slack:
+    rooms:
+      - secure: ESkZY5bzNWua0eHc9rBkuE7AZrCNzLeCV1Rtn97h9KIBeuxsiB3heDUAOi3xZkqO4AyKD5AitAM2k7dTdQKvC8WMooHFWFdjlsSepUvjJISy8keY9kiXywUJ1S/YCwMPwT+HAWB4Qk2zyKmlLmZ8IfAK5aBtndXFQFQCqyeW4PE=
+      - secure: NlXxYbeVV7mWDTUgeFK0VrUdXGBF4lPVpMLZ3WXYDTUWfFyM8tiChENo/u/9n7tSz6KIxdWpy0j7h8+EjVUVCGxS+4q+kdzkfm1Vwq3ANhMsGBDcwdm7gYWhdd43aXV9ZaZPVUWv5C3yizzmYXeuNtviFDA5DEvrE5Rdp6sBsRE=
+    on_success: change
+    on_failure: always
+    on_pull_requests: false
 
 # reduce depth (history) of git checkout
 git:

--- a/doc/docker/install.yml
+++ b/doc/docker/install.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
      - install_db
     environment:
+     - COMPOSER_MEMORY_LIMIT
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG
      - DATABASE_USER


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-29455

Added:
- notifications for Slack on broken builds.
- running PlatformUI tests on Varnish

Currently the build for 1.7 is failing because of Composer exceeding memory limits - I've increased it to 2GB (tested that 1GB is too low).