### PR TITLE
[YML] Add default cache prefix in order to share cache across cluster 

### DIFF
--- a/app/config/cache_pool/cache.memcached.yml
+++ b/app/config/cache_pool/cache.memcached.yml
@@ -8,3 +8,10 @@ services:
               # Example from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/MemcachedTrait.php:
               # memcached://user:pass@localhost?weight=33'
               provider: 'memcached://%cache_dsn%'
+              # Cache namespace prefix overriding the one used by Symfony globally
+              # This makes sure cache is reliably shared across whole cluster and all Symfony env's
+              # Can be used for blue/green deployment strategies when changes affect content cache.
+              # For multi db setup adapt this to be unique per pool (one pool per database)
+              # If you prefer default behaviour set this to null or comment out, and consider for instance:
+              # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
+              namespace: '%cache_namespace%'

--- a/app/config/cache_pool/cache.redis.yml
+++ b/app/config/cache_pool/cache.redis.yml
@@ -10,3 +10,10 @@ services:
               # redis://secret@example.com:1234/13
               # redis://secret@/var/run/redis.sock/13?persistent_id=4&class=Redis&timeout=3&retry_interval=3
               provider: 'redis://%cache_dsn%'
+              # Cache namespace prefix overriding the one used by Symfony by default
+              # This makes sure cache is reliably shared across whole cluster and all Symfony env's
+              # Can be used for blue/green deployment strategies when changes affect content cache.
+              # For multi db setup adapt this to be unique per pool (one pool per database)
+              # If you prefer default behaviour set this to null or comment out, and consider for instance:
+              # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
+              namespace: '%cache_namespace%'

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -36,8 +36,8 @@ parameters:
     # Cache DSN, see app/config/services/cache.yml for examples:
     cache_dsn: '%env(CACHE_DSN)%'
     
-    # Cache namespace prefix for use with Redis/Memcached
-    # For further info see: app/config/cache_pool/
+    # Cache namespace prefix for use with Redis/Memcached, 'ez' by default. 
+    # For further info incl alternatives for "blue/green deployment" and multi repo installs, see: app/config/cache_pool/*.yml
     cache_namespace: '%env(CACHE_NAMESPACE)%'
 
     # Settings for HttpCache
@@ -71,8 +71,8 @@ parameters:
     env(CACHE_POOL): "cache.app"
 
     env(CACHE_DSN): localhost
-    
-    env(CACHE_NAMESPACE): v1.mysite
+
+    env(CACHE_NAMESPACE): ez
 
     env(HTTPCACHE_PURGE_SERVER): "http://localhost:80"
 

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -36,11 +36,9 @@ parameters:
     # Cache DSN, see app/config/services/cache.yml for examples:
     cache_dsn: '%env(CACHE_DSN)%'
     
-    # Gobal Cache namespace prefix for use by Symfony Cache
-    # By default (when not set) Symfony will use root path as seed when generating sha for cache namespace prefix.
-    # Can theoretically be used to version cache, however will affect all usage, incl Symfony's internal app cache
-    # For setting prefix specifically on a given cache pool instead, set namespace on service in app/config/cache_pool/
-    cache.prefix.seed: '%env(CACHE_PREFIX)%'
+    # Cache namespace prefix for use with Redis/Memcached
+    # For further info see: app/config/cache_pool/
+    cache_namespace: '%env(CACHE_NAMESPACE)%'
 
     # Settings for HttpCache
     purge_server: '%env(HTTPCACHE_PURGE_SERVER)%'
@@ -74,7 +72,7 @@ parameters:
 
     env(CACHE_DSN): localhost
     
-    env(CACHE_PREFIX): ~
+    env(CACHE_NAMESPACE): v1.mysite
 
     env(HTTPCACHE_PURGE_SERVER): "http://localhost:80"
 

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -35,6 +35,12 @@ parameters:
 
     # Cache DSN, see app/config/services/cache.yml for examples:
     cache_dsn: '%env(CACHE_DSN)%'
+    
+    # Gobal Cache namespace prefix for use by Symfony Cache
+    # By default (when not set) Symfony will use root path as seed when generating sha for cache namespace prefix.
+    # Can theoretically be used to version cache, however will affect all usage, incl Symfony's internal app cache
+    # For setting prefix specifically on a given cache pool instead, set namespace on service in app/config/cache_pool/
+    cache.prefix.seed: '%env(CACHE_PREFIX)%'
 
     # Settings for HttpCache
     purge_server: '%env(HTTPCACHE_PURGE_SERVER)%'
@@ -67,6 +73,8 @@ parameters:
     env(CACHE_POOL): "cache.app"
 
     env(CACHE_DSN): localhost
+    
+    env(CACHE_PREFIX): ~
 
     env(HTTPCACHE_PURGE_SERVER): "http://localhost:80"
 


### PR DESCRIPTION
Overrides the default cache namespace: https://github.com/symfony/symfony/blob/3.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php#L33-L38

This makes sure cache is shared across a cluster no matter what the path of install is used or what Symfony Env you are using, hence making sure changes done on a dev env is affecting prod as well _(if those use different db's then inline doc here implies separate namespace should be used, or user should opt for default behavior instead)_


Open questions:
- Should this be master only maybe, as it affects cache logic for deployments and thus might be a bit intrusive to ship in a patch release

Todo:
- Doc, once approach is approved


-------
@emodric You'll see two first commits here with different approaches. In the end _(as of second commit)_ I think I agree with you, usage of cache seed prefix will:
1. affect other caches as well, so not good for mutli db installs as you tpyically _want_ to share symfony's internal app caches between the different db's
2. It will still use Symfony env as seed for namespace, meaning if some install is using several cache won't be properly cleared across envs. _(This is also the case when using file based regardless of this)_

Downside is cache service id is no longer automatically part of namespace, so multi db installs will need more adaption then before. 