### PR TITLE
[SESSION] Configuration is not correct

### DIFF
--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -43,9 +43,6 @@ parameters:
     # using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
     httpcache_default_ttl: '%env(HTTPCACHE_DEFAULT_TTL)%'
 
-    # Session save path as used by symfony session handlers (eg. used for dsn with redis)
-    ezplatform.session.save_path: '%env(SESSION_SAVE_PATH)%'
-
     # Recommendation Bundle params
     ez_recommendation.default.yoochoose.customer_id: '%env(RECOMMENDATIONS_CUSTOMER_ID)%'
     ez_recommendation.default.yoochoose.license_key: '%env(RECOMMENDATIONS_LICENSE_KEY)%'
@@ -95,9 +92,12 @@ parameters:
     # env: HTTPCACHE_PURGE_TYPE
     purge_type: local
 
-    ## Session handler, by default set to file based (instead of ~) in order to be able to use %ezplatform.session.save_path%
-    # env: SESSION_HANDLER_ID
-    ezplatform.session.handler_id: session.handler.native_file
+    ## Session handler, by default relying on the php.ini
+    # env: SESSION_HANDLER_ID (to override it)
+    ezplatform.session.handler_id: ~
+    # Used when ezplatform.session.handler_id is not null
+    # env: SESSION_SAVE_PATH (to override it)
+    ezplatform.session.save_path: ~
 
     # Admin siteaccess group name
     admin_group_name: admin_group

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -71,3 +71,7 @@ if ($value = getenv('LOG_TYPE')) {
 if ($value = getenv('SESSION_HANDLER_ID')) {
     $container->setParameter('ezplatform.session.handler_id', $value);
 }
+
+if ($value = getenv('SESSION_SAVE_PATH')) {
+    $container->setParameter('ezplatform.session.save_path', $value);
+}

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -105,7 +105,7 @@ if (isset($relationships['redissession'])) {
         }
 
         $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
-        $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+        $container->setParameter('ezplatform.session.save_path', sprintf('tcp://%s:%d', $endpoint['host'], $endpoint['port']));
     }
 } elseif (isset($relationships['rediscache'])) {
     foreach ($relationships['rediscache'] as $endpoint) {
@@ -114,6 +114,6 @@ if (isset($relationships['redissession'])) {
         }
 
         $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
-        $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+        $container->setParameter('ezplatform.session.save_path', sprintf('tcp://%s:%d', $endpoint['host'], $endpoint['port']));
     }
 }


### PR DESCRIPTION
This PR associated with:

Define that `php.ini` is the default configuration.

Then you can update that configuration through env. (current is `file` by default and that is not possible to override it (cause `null` value would NOT pass in the `if` in `generic.php`)

Also the kernel does not use `ezplatform.session.save_path` at all, then I am really confused.

It fixes also the save path for redis `tcp://`

> I did not really test live from a from scratch install