### PR TITLE
EZP-29034: Cannot install ezplatform on 1.7 branch

### DIFF
--- a/app/console
+++ b/app/console
@@ -18,6 +18,15 @@ use eZ\Bundle\EzPublishCoreBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
+// Enforce no-warmup on PHP5 because of class cache issue EZP-29034
+if (
+    PHP_VERSION_ID < 70000 &&
+    in_array('cache:clear', $_SERVER['argv']) &&
+    !in_array('--no-warmup', $_SERVER['argv'])
+) {
+    $_SERVER['argv'][] = '--no-warmup';
+}
+
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';

--- a/app/console
+++ b/app/console
@@ -18,15 +18,6 @@ use eZ\Bundle\EzPublishCoreBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
-// Enforce no-warmup on PHP5 because of class cache issue EZP-29034
-if (
-    PHP_VERSION_ID < 70000 &&
-    in_array('cache:clear', $_SERVER['argv']) &&
-    !in_array('--no-warmup', $_SERVER['argv'])
-) {
-    $_SERVER['argv'][] = '--no-warmup';
-}
-
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';

--- a/web/app.php
+++ b/web/app.php
@@ -18,12 +18,12 @@ if (($useDebugging = getenv('SYMFONY_DEBUG')) === false || $useDebugging === '')
     $useDebugging = $environment === 'dev';
 }
 
-// Depending on SYMFONY_CLASSLOADER_FILE use custom class loader, otherwise use bootstrap cache, or autoload in debug
+// Depending on SYMFONY_CLASSLOADER_FILE use custom class loader, otherwise use bootstrap cache on PHP 5, or autoload in debug and PHP 7
 if ($loaderFile = getenv('SYMFONY_CLASSLOADER_FILE')) {
     require_once $loaderFile;
 } else {
     require_once __DIR__ . '/../app/autoload.php';
-    if (!$useDebugging) {
+    if (!$useDebugging && PHP_VERSION_ID < 70000) {
         require_once __DIR__ . '/../app/bootstrap.php.cache';
     }
 }

--- a/web/app.php
+++ b/web/app.php
@@ -36,8 +36,9 @@ if ($useDebugging) {
 
 $kernel = new AppKernel($environment, $useDebugging);
 
-// we don't want to use the classes cache if we are in a debug session
-if (!$useDebugging) {
+// we don't want to use the class cache if we are in a debug session
+// Also not on PHP7+ where it does not give benefit (if using composer optimize autoload), only downsides remains
+if (!$useDebugging && PHP_VERSION_ID < 70000) {
     $kernel->loadClassCache();
 }
 

--- a/web/app.php
+++ b/web/app.php
@@ -18,7 +18,7 @@ if (($useDebugging = getenv('SYMFONY_DEBUG')) === false || $useDebugging === '')
     $useDebugging = $environment === 'dev';
 }
 
-// Depending on SYMFONY_CLASSLOADER_FILE use custom class loader, otherwise use bootstrap cache on PHP 5, or autoload in debug and PHP 7
+// Depending on SYMFONY_CLASSLOADER_FILE use custom class loader, otherwise use normal autoload and optionally bootstrap cache on PHP 5 when not in debug mode
 if ($loaderFile = getenv('SYMFONY_CLASSLOADER_FILE')) {
     require_once $loaderFile;
 } else {


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-29034

Since friendsofsymfony/http-cache version 1.4.5, eZ Platform 1.7 branch can't be installed or used unless one uses --no-warmup on cache clear commands, or clears caches with rm -rf. Class cache generated by the console conflicts with that from web.

This fixes it by:
- Cherry-picking https://github.com/ezsystems/ezplatform/commit/5fdf60c698760eda387286d5885ffe67ee32191f which ensures class cache is not used on PHP7, as it has no performance benefit there (Also: Disable bootstrap.php.cache on PHP 7 so we are in sync with how Symfony does it)
- Ensure that when cache is cleared by console command in PHP5, --no-warmup is enforced. https://github.com/ezsystems/ezplatform/commit/7e6b4716480d16e45d0ac4bd75b2b319cff42ff7 This is a filthy hack 💩 **UPDATE: The hack is now reverted and replaced by this cleaner approach** https://github.com/ezsystems/ezpublish-kernel/pull/2415