### PR TITLE
Default to utf8mb4 charset

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,7 @@ doctrine:
                 dbname: '%database_name%'
                 user: '%database_user%'
                 password: '%database_password%'
-                charset: UTF8
+                charset: utf8mb4
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/app/config/dfs/dfs.yml
+++ b/app/config/dfs/dfs.yml
@@ -9,7 +9,7 @@ doctrine:
                 user: "%dfs_database_user%"
                 password: "%dfs_database_password%"
                 dbname: "%dfs_database_name%"
-                charset: UTF8
+                charset: utf8mb4
 
 # define the flysystem handler
 oneup_flysystem:


### PR DESCRIPTION
Default to utf8mb4 charset in eZ Platform, since we're defaulting to utf8mb4 in 2.2+ kernel schema.
(merge in 2.2 & master)