### PR TITLE
[Docker + p.sh] Switch to PHP 7.2 & change Dockerfiles to take version by ARG

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.1-v1
-PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
+PHP_IMAGE=ezsystems/php:7.2-v1
+PHP_IMAGE_DEV=ezsystems/php:7.2-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
 SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.4.0

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -8,7 +8,7 @@
 name: app
 
 # The type of the application to build.
-type: php:7.1
+type: php:7.2
 build:
     # "none" means we're running composer manually, see build hook
     flavor: "none"

--- a/doc/docker/Dockerfile-app
+++ b/doc/docker/Dockerfile-app
@@ -1,4 +1,5 @@
-FROM ezsystems/php:7.1-v1 as builder
+ARG PHP_IMAGE=ezsystems/php:7.2-v1
+FROM ${PHP_IMAGE} as builder
 
 # This is prod image (for dev use just mount your application as host volume into php image we extend here)
 ENV SYMFONY_ENV=prod
@@ -26,7 +27,7 @@ RUN rm -Rf app/logs/* app/cache/*/*
 RUN rm -rf web/css web/fonts web/js web/var
 
 
-FROM ezsystems/php:7.1-v1
+FROM ${PHP_IMAGE}
 
 # This is prod image (for dev use just mount your application as host volume into php image we extend here)
 ENV SYMFONY_ENV=prod

--- a/doc/docker/Dockerfile-nginx
+++ b/doc/docker/Dockerfile-nginx
@@ -1,4 +1,5 @@
-FROM ezsystems/php:7.1-v1 as web-build
+ARG PHP_IMAGE=ezsystems/php:7.2-v1
+FROM ${PHP_IMAGE} as web-build
 
 ENV SYMFONY_ENV=prod
 

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ../../
       dockerfile: ${APP_DOCKER_FILE}
+      args:
+       - PHP_IMAGE
     depends_on:
      - db
     environment:
@@ -28,6 +30,8 @@ services:
     build:
       context: ../../
       dockerfile: doc/docker/Dockerfile-nginx
+      args:
+       - PHP_IMAGE
     depends_on:
      - app
     ports:

--- a/doc/docker/distribution.yml
+++ b/doc/docker/distribution.yml
@@ -14,7 +14,7 @@ services:
      - backend
 
   app:
-    image: ezsystems/php:7.1-v1
+    image: ${PHP_IMAGE}
     depends_on:
      - db
      - distribution
@@ -39,7 +39,7 @@ services:
      - vardir:/var/www/web/var
 
   web:
-    image: nginx:stable
+    image: ${NGINX_IMAGE}
     depends_on:
      - distribution
      - app


### PR DESCRIPTION
PHP 7.2 should be rather stable now both on our side _(ezpublish-legacy just got patches as well)_, p.sh side and php side. So time to take advantage of the 5-7% speedup :)

As a minor bonus 7.2 image is also [38mb smaller](https://hub.docker.com/r/ezsystems/php/tags/) as it builds on Debian 9 _(:stretch-slim)_ instead of 8 _(:jessie)_.

This also adapts Dockerfiles to not hard code php image we use, in order to cleanup here and also get rid of things like https://github.com/ezsystems/docker-php/blob/master/bin/.travis/test.sh#L80-L86.