### PR TITLE
EZP-29570: Add screenshots for Behat on Travis

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -25,6 +25,13 @@ default:
 
         EzSystems\PlatformBehatBundle\ServiceContainer\EzBehatExtension: ~
 
+        Bex\Behat\ScreenshotExtension:
+            active_image_drivers: cloudinary
+            image_drivers:
+                cloudinary:
+                    cloud_name: ezplatformtravis
+                    preset: ezplatform
+
     # default profile: no suites
     suites: ~
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
         "behat/mink-goutte-driver": "*",
         "behat/mink-selenium2-driver": "*",
         "jarnaiz/behat-junit-formatter": "^1.3",
-        "ezsystems/behatbundle": "^6.3"
+        "ezsystems/behatbundle": "^6.3",
+        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.0",
+        "bex/behat-screenshot": "^1.2"
     },
     "suggest": {
         "ezsystems/legacy-bridge": "Provides the full legacy backoffice and legacy features"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-29570

This PR adds Behat screenshots for Travis.

### Introduction/assumptions

It's extremely useful to see a screenshot taken in the moment when a Behat Selenium test failed - this speed immensely test debugging. The solution should ideally be:
- available both for public and enterprise bundles
- free
- available in PRs from forks for community PRs

### Research:

By default, Travis only allows uploading artifacts to Amazon S3, which I don't think suits us (while cheap it's not free after a year and I'd be a little bit worried of leaking the credentials in the public).

There are Behat extensions that allow for using other image hosting services, such as:
- https://github.com/Lakion/MinkDebugExtension
- https://packagist.org/packages/bex/behat-screenshot

The first one works only with Imgur, which is not free commercially ("Commercial usage" paragraph on https://apidocs.imgur.com). The second one comes with 3 potential hosting services out of the box:
1) uploadpie.com - on Monday and Thuesday the website was down without any message
2) img42.com - is down
3) unsee - sadly, the driver is no longer working (and there is no official API).

That's why I've decided to create my own driver for the extension, using Cloudinary.
Cloudinary has:
1) a free plan that should cover all our needs (https://cloudinary.com/pricing)
2) convenient API (with [unsigned upload](https://cloudinary.com/documentation/upload_images#unsigned_upload) being the thing that's most interesting for us)

It's available here: https://github.com/mnocon/behat-screenshot-image-driver-cloudinary (feel free to look at the source code as well, it's quite small).

### Testing
I have two PRs to test the solution:
1) PlatformUI: https://github.com/ezsystems/PlatformUIBundle/pull/985 - where the feature is working
2) Kernel: https://github.com/ezsystems/ezpublish-kernel/pull/2438 - to make sure that tests that are not capable of taking screenshots are still passing

### Other
To perform a Cloudinary upload two values are needed: cloud name and preset. I'd love to specify them as Travis environmental variables instead of hardcoding them in `behat.yml.dist`, but there are some issues with that:
1) Defining them in `travis.yml` as env variables is essentially the same, with a negative consequence of having to add them in every repository (PlatformUI, StudioUI etc.)
2) Defining them as Travis variables (using UI) makes them unavailable for forks (https://docs.travis-ci.com/user/environment-variables/)

So, so far they're hardcoded there as I don't see a better approach. I'm a little bit worried that people creating forks of ezplatform can use our token when running on Travis - so far the only solution I've come with is monitoring Cloudinary weekly to see whether we are approaching free plan quota. I don't think it's a big issue, this support entry summaries it nicely: https://support.cloudinary.com/hc/en-us/articles/208335975-How-safe-secure-is-it-to-use-unsigned-upload-from-web-browsers-or-mobile-clients-

TO DO:
- [x] if this approach is accepted - change the `dev-master` requirement of Cloudinary driver into a tag
- [x] Discuss: can the ownership of the driver stay this way, do we want to transfer it to `ez`?




