### PR TITLE
[Travis] Improve PlatformUI stability, set COMPOSER_MEMORY_LIMIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,12 @@ env:
     - SYMFONY_DEBUG=1
   # list of behat arguments to test
   matrix:
-    - TEST_CMD="bin/behat -vv --profile=rest --suite=fullJson --tags=~@broken" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
-    - TEST_CMD="bin/behat -vv --profile=rest --suite=fullXml --tags=~@broken"
-    - TEST_CMD="bin/behat -vv --profile=core --tags=~@broken"
-    - TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
-    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-    - TEST_CMD="bin/behat -vv --profile=platformui --tags='@common'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
-
+    - TEST_CMD="./bin/.travis/runcommand.sh bin/behat -vv  --colors --profile=rest --suite=fullJson --tags=~@broken" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
+    - TEST_CMD="./bin/.travis/runcommand.sh bin/behat -vv  --colors --profile=rest --suite=fullXml --tags=~@broken"
+    - TEST_CMD="./bin/.travis/runcommand.sh bin/behat -vv  --colors --profile=core --tags=~@broken"
+    - TEST_CMD="./bin/.travis/runcommand.sh bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
+    - TEST_CMD="travis_retry ./bin/.travis/runcommand.sh bin/behat -vv  --colors --profile=platformui --tags='@common' --rerun" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+    - TEST_CMD="travis_retry ./bin/.travis/runcommand.sh bin/behat -vv  --colors --profile=platformui --tags='@common' --rerun" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
 
 # test only master (+ Pull requests)
 branches:
@@ -47,7 +46,10 @@ before_script:
 
 # Execute test command, need to use sh to get right exit code (docker/compose/issues/3379)
 # Behat will use behat.yml which is a copy of behat.yml.dist with hostnames update by doc/docker/selenium.yml
-script: docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php $TEST_CMD"
+script: 
+  - docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php;"
+  - eval "$TEST_CMD"
+
 
 after_failure:
   # Will show us the last bit of the log of container's main processes

--- a/bin/.travis/runcommand.sh
+++ b/bin/.travis/runcommand.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "" ]; then
+    echo "Argument 1 variable for command arguments is empty, please pass arguments"
+    exit 1
+fi
+
+# Execute test command, need to use sh to get right exit code (docker/compose/issues/3379)
+CMD=\"$@\"
+docker-compose exec -T --user www-data app bash -c \""$CMD"\"

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -10,6 +10,7 @@ services:
     depends_on:
      - db
     environment:
+     - COMPOSER_MEMORY_LIMIT
      - SYMFONY_ENV=${SYMFONY_ENV-dev}
      - SYMFONY_DEBUG
      - SYMFONY_HTTP_CACHE

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -9,6 +9,7 @@ services:
     depends_on:
      - db
     environment:
+     - COMPOSER_MEMORY_LIMIT
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG
      - SYMFONY_HTTP_CACHE


### PR DESCRIPTION
### Adding COMPOSER_MEMORY_LIMIT to app container: 

This is a followup to comment in https://github.com/ezsystems/ezplatform-demo/pull/92/files/b83035746dbf73caaa8d34edbab798814711ee15#diff-12e91abffee0d4e830c705c6d7258aa7R94

When developing tests across different repositories we're sometimes adding temporary Composer dependencies ([example of how it's done](https://gist.github.com/mnocon/c61372eba4f369f3e45cb9e962444fe5)). This operation performs composer operations directly on the `app` container, which does not use `COMPOSER_MEMORY_LIMIT` (it's only set for `install_app` - https://github.com/ezsystems/ezplatform/commit/add8d279f1d7b3b2666bb72935ff23c795bf812c#diff-12da65584b74987bec78f37c6b423dbfL23). For me it makes sense to set the value in `app` too.

### Rerun failed PlatformUI Behat tests

Sometimes the tests are failing, because there are concurrency issues when clearing cache after tests - all tests are passed, but because of issue that happened in `AfterScenario` phase build is marked as failed. I hope that using `travis_retry ... --rerun` will account for that and the issue won't occur again. This approach is used already in some StudioUI jobs, for example: https://github.com/ezsystems/StudioUIBundle/blob/1.7/.travis.yml#L73

~EDIT: it's marked as WIP, as I'm testing whether the failures are retried & reported correctly.~ It works as expected 🎉 