### PR TITLE
Removing Apache timeout configuration. 

### DIFF
--- a/doc/apache2/Readme.md
+++ b/doc/apache2/Readme.md
@@ -90,8 +90,7 @@ If you do not have an access to use virtualhost config, use the `.htaccess` file
 
     DirectoryIndex app.php
 
-    # Set default timeout to 90s, and max upload to 48mb
-    TimeOut 90
+    # Set default max upload to 48mb
     LimitRequestBody 50331648
 
     # Disabling MultiViews prevents unwanted negotiation, e.g. "/app" should not resolve

--- a/doc/apache2/vhost.2.2.template
+++ b/doc/apache2/vhost.2.2.template
@@ -14,9 +14,6 @@
     # Request size limit in bytes, 0 to disable
     LimitRequestBody %BODY_SIZE_LIMIT%
 
-    # Request timeout limit in seconds, 0 to disable
-    TimeOut %TIMEOUT%
-
     # Enabled for Dev environment
     #LogLevel debug
 

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -13,9 +13,6 @@
     # Request size limit in bytes, 0 to disable
     LimitRequestBody %BODY_SIZE_LIMIT%
 
-    # Request timeout limit in seconds, 0 to disable
-    TimeOut %TIMEOUT%
-
     # Enabled for Dev environment
     #LogLevel debug
 


### PR DESCRIPTION
It as not much of a value and is too risky to be used wrong. The disable option is not known to any Apache version.

60 hours time wasted to resolve performance issues. Do not mess with it.
```bash
[root@localhost docker-httpd-test]# wget http://127.0.0.1:8096/100MB.bin              
--2018-09-16 03:44:16--  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 200 OK
Length: 23391726 (22M) [application/octet-stream]
Saving to: ‘100MB.bin.1’

 1% [>                                                                                                                      ] 305,198     --.-K/s   in 0.02s   

2018-09-16 03:44:16 (15.5 MB/s) - Connection closed at byte 305198. Retrying.

--2018-09-16 03:44:17--  (try: 2)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 23086528 (22M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 2% [+>                                                                                                                     ] 587,168     --.-K/s   in 0.02s   

2018-09-16 03:44:17 (13.2 MB/s) - Connection closed at byte 587168. Retrying.

--2018-09-16 03:44:19--  (try: 3)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 22804558 (22M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 4% [++==>                                                                                                                  ] 998,010     --.-K/s   in 0.04s   

2018-09-16 03:44:19 (8.75 MB/s) - Connection closed at byte 998010. Retrying.

--2018-09-16 03:44:22--  (try: 4)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 22393716 (21M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 5% [+++++>                                                                                                                 ] 1,272,740   --.-K/s   in 0.01s   

2018-09-16 03:44:22 (22.3 MB/s) - Connection closed at byte 1272740. Retrying.

--2018-09-16 03:44:26--  (try: 5)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 22118986 (21M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 6% [++++++>                                                                                                                ] 1,547,469   --.-K/s   in 0.02s   

2018-09-16 03:44:26 (12.3 MB/s) - Connection closed at byte 1547469. Retrying.

--2018-09-16 03:44:31--  (try: 6)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 21844257 (21M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 8% [+++++++=>                                                                                                              ] 1,958,310   --.-K/s   in 0.03s   

2018-09-16 03:44:31 (14.0 MB/s) - Connection closed at byte 1958310. Retrying.

--2018-09-16 03:44:37--  (try: 7)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 21433416 (20M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

 9% [+++++++++=>                                                                                                            ] 2,235,935   --.-K/s   in 0.01s   

2018-09-16 03:44:37 (22.2 MB/s) - Connection closed at byte 2235935. Retrying.

--2018-09-16 03:44:44--  (try: 8)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 21155791 (20M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

10% [+++++++++++>                                                                                                           ] 2,510,664   --.-K/s   in 0.02s   

2018-09-16 03:44:44 (13.0 MB/s) - Connection closed at byte 2510664. Retrying.

--2018-09-16 03:44:52--  (try: 9)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 20881062 (20M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

11% [++++++++++++=>                                                                                                         ] 2,785,393   --.-K/s   in 0.01s   

2018-09-16 03:44:52 (18.0 MB/s) - Connection closed at byte 2785393. Retrying.

--2018-09-16 03:45:01--  (try:10)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 20606333 (20M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

13% [++++++++++++++>                                                                                                        ] 3,083,290   --.-K/s   in 0.03s   

2018-09-16 03:45:01 (10.3 MB/s) - Connection closed at byte 3083290. Retrying.

--2018-09-16 03:45:11--  (try:11)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 20308436 (19M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

15% [+++++++++++++++==>                                                                                                     ] 3,607,075   --.-K/s   in 0.02s   

2018-09-16 03:45:11 (20.9 MB/s) - Connection closed at byte 3607075. Retrying.

--2018-09-16 03:45:21--  (try:12)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 19784651 (19M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

17% [++++++++++++++++++=>                                                                                                   ] 4,107,692   --.-K/s   in 0.05s   

2018-09-16 03:45:22 (10.1 MB/s) - Connection closed at byte 4107692. Retrying.

--2018-09-16 03:45:32--  (try:13)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 19284034 (18M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

18% [++++++++++++++++++++=>                                                                                                 ] 4,382,421   --.-K/s   in 0.01s   

2018-09-16 03:45:32 (23.5 MB/s) - Connection closed at byte 4382421. Retrying.

--2018-09-16 03:45:42--  (try:14)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 19009305 (18M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’

21% [++++++++++++++++++++++==>                                                                                              ] 5,016,254   --.-K/s   in 0.04s   

2018-09-16 03:45:42 (15.0 MB/s) - Connection closed at byte 5016254. Retrying.

--2018-09-16 03:45:52--  (try:15)  http://127.0.0.1:8096/100MB.bin
Connecting to 127.0.0.1:8096... connected.
HTTP request sent, awaiting response... 206 Partial Content
Length: 23391726 (22M), 18375472 (18M) remaining [application/octet-stream]
Saving to: ‘100MB.bin.1’
```