### PR TITLE
Retting rid of "W: The minimum interval between cron runs is 5 minute…

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -52,7 +52,7 @@ web:
             expires: 600
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 3072
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -107,9 +107,11 @@ hooks:
 # see https://docs.platform.sh/configuration/app/cron.html#cron-jobs
 crons:
     frequent:
-        # https://docs.platform.sh/configuration/app/cron.html:
         # The minimum interval between cron runs is 5 minutes, even if specified as less.
-        spec: "*/5 * * * *"
+        # Except for PE. There crons can be run every minute.
+        # So if you are not on PE please change specs to "*/5 * * * *".
+        # Otherwise you will get Platform.sh warning on each deploy
+        spec: "* * * * *"
         cmd: "php bin/console ezplatform:cron:run"
     weekly:
         spec: "0 0 * * 0"

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -52,7 +52,7 @@ web:
             expires: 600
 
 # The size of the persistent disk of the application (in MB).
-disk: 3072
+disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -106,9 +106,10 @@ hooks:
 # The configuration of scheduled execution.
 # see https://docs.platform.sh/configuration/app/cron.html#cron-jobs
 crons:
-    minute:
-        # NOTE: Platform.sh PS does not execute every minute, so might sometimes miss jobs scheduled for a given time
-        spec: "* * * * *"
+    frequent:
+        # https://docs.platform.sh/configuration/app/cron.html:
+        # The minimum interval between cron runs is 5 minutes, even if specified as less.
+        spec: "*/5 * * * *"
         cmd: "php bin/console ezplatform:cron:run"
     weekly:
         spec: "0 0 * * 0"


### PR DESCRIPTION
Getting rid of 
```
Validating configuration files
  W: The minimum interval between cron runs is 5 minutes, even if specified as less.
```