### PR TITLE
EZP-29675: Correct JMS translations config to exclude node_modules folder from searching translations

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -137,11 +137,11 @@ jms_translation:
             dirs:
                 - '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui/src'
             output_dir: '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/'
-            excluded_dirs: [Behat, Tests]
+            excluded_dirs: [Behat, Tests, node_modules]
             output_format: "xliff"
         admin_modules:
             dirs:
                 - '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui-modules/src'
             output_dir: '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui-modules/Resources/translations/'
-            excluded_dirs: [Behat, Tests]
+            excluded_dirs: [Behat, Tests, node_modules]
             output_format: "xliff"


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-29675