### PR TITLE
Set solr_core variable from platform.sh relationships

### DIFF
--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -128,5 +128,6 @@ if (isset($relationships['solr'])) {
 
         $container->setParameter('search_engine', 'solr');
         $container->setParameter('solr_dsn', sprintf('http://%s:%d/%s', $endpoint['host'], $endpoint['port'], 'solr'));
+        $container->setParameter('solr_core', substr($endpoint['path'], 5));
     }
 }


### PR DESCRIPTION
This fixes a bug for ezplatform platform.sh customers with enterprise subscriptions. Platform.sh creates solr_cores named after the environment and not from the platform.sh services.yml file. You need to set the solr_core variable dynamically from the solr relationship using the path entry.