### PR TITLE
Fixed bug in solr template for Platform.sh

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -26,7 +26,7 @@ relationships:
     # this relationship and the corresponding service in .platform/services.yaml
     #redissession: 'redissession:redis'
     # If you wish to use solr, uncomment this relationship and the corresponding service in .platform/services.yaml
-    #solr: 'solrsearch:solr'
+    #solr: 'solrsearch:collection1'
 
 variables:
     #php:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -35,6 +35,8 @@ rediscache:
 # If you wish to use solr, uncomment this service and the corresponding relationship in .platform.app.yaml.
 # Also, you need to generate the config using:
 # vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh
+# Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
+# unable to reach each other
 #solrsearch:
 #    type: solr:6.6
 #    disk: 512


### PR DESCRIPTION
Small bug in the solr template for Platform.sh

We need to point the `relationship` to the `endpoint` defined in [services.yml](https://github.com/ezsystems/ezplatform/blob/1.13/.platform/services.yaml#L50)