### PR TITLE
[WiP] EZP-28009: Extract the RichText FieldType to its own package

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -40,6 +40,7 @@ class AppKernel extends Kernel
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
             new EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle(),
             new EzSystems\EzPlatformStandardDesignBundle\EzPlatformStandardDesignBundle(),
+            new EzSystems\EzPlatformRichTextBundle\EzPlatformRichTextBundle(),
             new EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle(),
             new EzSystems\EzPlatformAdminUiModulesBundle\EzPlatformAdminUiModulesBundle(),
             new EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle(),

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "ezsystems/ezplatform-admin-ui-assets": "^3.1@dev",
         "ezsystems/ezplatform-design-engine": "^2.0@dev",
         "ezsystems/ezplatform-standard-design": "^0.1@dev",
+        "ezsystems/ezplatform-richtext": "^1.0@dev",
         "ezsystems/ezplatform-cron": "^2.0@dev",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "willdurand/js-translation-bundle": "^2.6.6",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28009](https://jira.ez.no/browse/EZP-28009)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `2.4`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | yes

This PR enables eZ Platform RichText Bundle available via the [`ezsystems/ezplatform-richtext`](https://github.com/ezsystems/ezplatform-richtext) package.

The Bundle is a replacement for `ezrichtext` Field Type available via the [`ezsystems/ezpublish-kernel`](https://github.com/ezsystems/ezpublish-kernel) package (`eZ\Publish\Core\FieldType\RichText` namespace).

**TODO**:
- [ ] Fix remaining issues.
- [ ] Test by QA.