### PR TITLE
EZP-29830: Disable executables in the var directory

### DIFF
--- a/doc/apache2/Readme.md
+++ b/doc/apache2/Readme.md
@@ -64,6 +64,9 @@ Example config for Apache 2.4 in prefork mode:
         # Sets the HTTP_AUTHORIZATION header sometimes removed by Apache
         RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+        # Disable .php(3) and other executable extensions in the var directory
+        RewriteRule ^var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$ - [F]
+
         # Access to repository images in single server setup
         RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* - [L]
 
@@ -111,6 +114,9 @@ If you do not have an access to use virtualhost config, use the `.htaccess` file
     # Sets the HTTP_AUTHORIZATION header sometimes removed by Apache
     RewriteCond %{HTTP:Authorization} .
     RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+    # Disable .php(3) and other executable extensions in the var directory
+    RewriteRule ^var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$ - [F]
 
     # Makes it possible to placed your favicon and robots.txt at the root of your web folder
     RewriteRule ^favicon\.ico - [L]

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -77,6 +77,9 @@
         RewriteCond %{REQUEST_URI} ^/php5-fcgi(.*)
         RewriteRule . - [L]
 
+        # Disable .php(3) and other executable extensions in the var directory
+        RewriteRule ^var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$ - [F]
+
         # Cluster/streamed files rewrite rules. Enable on cluster with DFS as a binary data handler
         #RewriteRule ^/var/([^/]+/)?storage/images(-versioned)?/.* /app.php [L]
 

--- a/doc/nginx/Readme.md
+++ b/doc/nginx/Readme.md
@@ -69,6 +69,11 @@ Example config:
                 # Defaults to "prod" if omitted
                 fastcgi_param SYMFONY_ENV prod;
             }
+
+            # Disable .php(3) and other executable extensions in the var directory
+            location ~ ^/var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$ {
+                return 403;
+            }
         }
 
         include ez_params.d/ez_server_params;

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -66,6 +66,11 @@ server {
             # Defaults to not be set if env value is omitted or empty
             #if[SYMFONY_TRUSTED_PROXIES] fastcgi_param SYMFONY_TRUSTED_PROXIES "%SYMFONY_TRUSTED_PROXIES%";
         }
+
+        # Disable .php(3) and other executable extensions in the var directory
+        location ~ ^/var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$ {
+            return 403;
+        }
     }
 
     # Custom logs


### PR DESCRIPTION
> Implement https://jira.ez.no/browse/EZP-29830
> Ready for review

In the wake of [EZSA-2018-009](http://share.ez.no/community-project/security-advisories/ezsa-2018-009-do-not-interpret-php-phar-uploads) we should change the web server readmes and vhost templates accordingly.

This will return `HTTP 403 Forbidden` for such files, which is easy to track in dedicated log files, if wanted.