### PR TITLE
Added build argument DISTRIBUTION_IMAGE to Dockerfile-distribution

### DIFF
--- a/doc/docker/Dockerfile-distribution
+++ b/doc/docker/Dockerfile-distribution
@@ -1,6 +1,7 @@
-# Note : if you set the environment variable COMPOSE_PROJECT_NAME to a non-default value, you'll need to change the
-# image name in here too
-FROM docker_app as builder
+# Note : if you set the environment variable COMPOSE_PROJECT_NAME to a non-default value, you'll need to set the
+# DISTRIBUTION_IMAGE build arg too (for instance docker-compose build --no-cache --build-arg DISTRIBUTION_IMAGE=customprojectname_app distribution)
+ARG DISTRIBUTION_IMAGE=docker_app
+FROM ${DISTRIBUTION_IMAGE} as builder
 
 RUN composer config extra.symfony-assets-install hard
 RUN composer run-script post-install-cmd --no-interaction

--- a/doc/docker/README.md
+++ b/doc/docker/README.md
@@ -227,9 +227,6 @@ image. The downside of this approach is that all eZ Platform code is copied to a
 other containers. This means bigger disk space footprint and longer loading time of the containers.
 It is also more complicated to make this approach work with docker stack so only a docker-compose example is provided.
 
-Note that if you set the environment variable COMPOSE_PROJECT_NAME to a non-default value, you'll need to change the image name in
-doc/docker/Dockerfile-distribution accordingly.
-
 ```sh
 export COMPOSE_FILE=doc/docker/base-prod.yml:doc/docker/create-dataset.yml:doc/docker/distribution.yml
 # If not already done, install setup, and generate database dump :
@@ -242,6 +239,10 @@ docker-compose -f doc/docker/base-prod.yml build --no-cache app
 
 # Optional, only build the images, do not create containers
 docker-compose build --no-cache distribution
+
+# Note that if you set the environment variable COMPOSE_PROJECT_NAME to a non-default value, you'll need to use set the
+# build argument DISTRIBUTION_IMAGE when building the distribution image
+docker-compose build --no-cache --build-arg DISTRIBUTION_IMAGE=customprojectname_app distribution
 
 # Build the "distribution" and dataset images, then start the containers
 docker-compose up -d


### PR DESCRIPTION
This PR makes it possible to change COMPOSE_PROJECT_NAME without altering doc/docker/Dockerfile-distribution.

Instead you may use docker build argument as documented  in README
