### PR TITLE
EZP-29985: Update Selenium container on Travis

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ PHP_IMAGE=ezsystems/php:7.2-v1
 PHP_IMAGE_DEV=ezsystems/php:7.2-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
-SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.4.0
+SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59
 REDIS_IMAGE=healthcheck/redis
 
 APP_DOCKER_FILE=doc/docker/Dockerfile-app


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-29985

Updating Chrome version on Travis.

Before: 60.0.3112.113 (released August 24, 2017)
After: 71.0.3578.98 (released December 12, 2018)

This PR is marked as WIP until I sort out all the issues related to the upgrade (in https://github.com/ezsystems/ezplatform-page-builder/pull/289).
