### PR TITLE
[Composer] Add conflict for Twig 2.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
     },
     "conflict": {
         "symfony/symfony": "3.4.9||3.4.12||3.4.16",
-        "doctrine/dbal": "2.7.0"
+        "doctrine/dbal": "2.7.0",
+        "twig/twig": "2.6.1"
     },
     "scripts": {
         "symfony-scripts": [


### PR DESCRIPTION
Twig 2.6.1 constains a breaking change/bug that breaks AdminUI - it's impossible to browse Content, Form and Page tabs in the Admin panel.

More about the issue: https://github.com/twigphp/Twig/issues/2810
Example failure:  https://res.cloudinary.com/ezplatformtravis/image/upload/v1547459400/screenshots/vendor_ezsystems_ezplatform-form-builder_features_formbuildertests_feature_11_c8a6wf.png
(taken from https://travis-ci.com/ezsystems/ezplatform-form-builder/jobs/170142669 )