### PR TITLE
Increase shared memory to 1gb

### DIFF
--- a/doc/docker/selenium.yml
+++ b/doc/docker/selenium.yml
@@ -14,7 +14,7 @@ services:
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: 512m
+    shm_size: '1gb'
 
   app:
     depends_on:


### PR DESCRIPTION
Recently (in https://github.com/ezsystems/ezplatform/pull/352) the shared memory has been bumped to 512mb. There are fewer failures, but they still sometimes happen, for example:
https://travis-ci.com/ezsystems/ezplatform-form-builder/builds/98801861?utm_source=slack&utm_medium=notification

I believe increasing it to 1gb will make the tests stable, as right now the failures happen rarely.

(I've used format from https://docs.docker.com/compose/compose-file/#shm_size )