### PR TITLE
[Composer] Use http-cache 0.7.x in 2.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ezsystems/ezplatform-admin-ui-modules": "~1.2.1@dev",
         "ezsystems/ezplatform-cron": "~2.0.0@dev",
         "ezsystems/ezplatform-design-engine": "~2.0.0@dev",
-        "ezsystems/ezplatform-http-cache": "~0.8@dev",
+        "ezsystems/ezplatform-http-cache": "~0.7@dev",
         "ezsystems/ezplatform-solr-search-engine": "^1.5.4@dev",
         "ezsystems/ezplatform-standard-design": "~0.1.0@dev",
         "ezsystems/ezpublish-kernel": "~7.2.1@dev",


### PR DESCRIPTION
Currently it's not possible to install 2.2 EE branch, example: https://travis-ci.com/ezsystems/ezplatform-page-builder/builds/99270204

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - ezsystems/ezplatform-page-fieldtype v1.0.1 requires ezsystems/ezplatform-http-cache ^0.7 -> satisfiable by ezsystems/ezplatform-http-cache[0.7.x-dev].
    - ezsystems/ezplatform-page-fieldtype v1.0.2 requires ezsystems/ezplatform-http-cache ^0.7 -> satisfiable by ezsystems/ezplatform-http-cache[0.7.x-dev].
    - ezsystems/ezplatform-page-fieldtype v1.0.3 requires ezsystems/ezplatform-http-cache ^0.7 -> satisfiable by ezsystems/ezplatform-http-cache[0.7.x-dev].
    - ezsystems/ezplatform-page-fieldtype v1.0.4 requires ezsystems/ezplatform-http-cache ^0.7 -> satisfiable by ezsystems/ezplatform-http-cache[0.7.x-dev].
    - ezsystems/ezplatform-page-fieldtype 1.0.x-dev requires ezsystems/ezplatform-http-cache ^0.7 -> satisfiable by ezsystems/ezplatform-http-cache[0.7.x-dev].
    - Conclusion: don't install ezsystems/ezplatform-http-cache 0.7.x-dev
    - Installation request for ezsystems/ezplatform-page-fieldtype ~1.0.1@dev -> satisfiable by ezsystems/ezplatform-page-fieldtype[v1.0.1, v1.0.2, v1.0.3, v1.0.4, 1.0.x-dev].
```

eZ Platform 2.2.x should use 0.7.x http-cache:
- v2.2.3 was using 0.7.0: https://github.com/ezsystems/ezplatform/blob/v2.2.3/composer.lock#L1238
- v2.2.3.1 was also using 0.7.0: https://github.com/ezsystems/ezplatform/blob/v2.2.3.1/composer.lock#L1238

Http-cache 0.8.0 has been released in October (https://github.com/ezsystems/ezplatform-http-cache/releases/tag/v0.8.0) - autumn release, 2.2 was a summer release.


