### PR TITLE
Limit number of screenshots to 10 for a single job

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -30,8 +30,11 @@ default:
             active_image_drivers: cloudinary
             image_drivers:
                 cloudinary:
+                    screenshot_directory: /tmp/behat-screenshot/
                     cloud_name: ezplatformtravis
                     preset: ezplatform
+                    mode: normal
+                    limit: 10
 
     suites: ~
 


### PR DESCRIPTION
https://github.com/ezsystems/behat-screenshot-image-driver-cloudinary/pull/2 is merged, so it should be possible now to limit the number of screenshots taken in a single test run.

We're using free plan of Cloudinary, which limits us to 20 000 screenshots in 30 days. That is a lot and is enough for our normal use, but the problem is in Pull Requests with dependencies: Travis tests are failing in them and a lot of screenshots is taken. 

Limiting the number of screenshots taken in a single job to 10 should limit the number when the PR is in WIP stage or has a dependency, but it should keep being useful when a PR really has issues.