### PR TITLE
[Composer] Increase Behat Cloudinary Screenshot version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "behat/mink-selenium2-driver": "^1.3.1",
         "behat/symfony2-extension": "^2.1.5",
         "bex/behat-screenshot": "^1.2.7",
-        "ezsystems/behat-screenshot-image-driver-cloudinary": "~1.0.0@dev",
+        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0@dev",
         "ezsystems/behatbundle": "~6.5.4@dev",
         "phpunit/phpunit": "^6.5.13",
         "sensio/generator-bundle": "^3.1.7",


### PR DESCRIPTION
Options added in https://github.com/ezsystems/ezplatform/pull/358 require `ezsystems/behat-screenshot-image-driver-cloudinary` in version 1.1.0 - it's downloaded in 2.3 branch, but not in this one.

Changed Composer requirement to allow for non-breaking updates.