### PR TITLE
EZP-29938: Enabled PostgreSQL support via DoctrineSchemaBuilder

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -37,6 +37,7 @@ class AppKernel extends Kernel
             new eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle(),
             new EzSystems\EzSupportToolsBundle\EzSystemsEzSupportToolsBundle(),
             new EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle(),
+            new EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle(),
             new EzSystems\RepositoryFormsBundle\EzSystemsRepositoryFormsBundle(),
             new EzSystems\EzPlatformSolrSearchEngineBundle\EzSystemsEzPlatformSolrSearchEngineBundle(),
             new EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,7 @@ doctrine:
                 dbname: '%database_name%'
                 user: '%database_user%'
                 password: '%database_password%'
-                charset: utf8mb4
+                charset: '%database_charset%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,6 +29,13 @@ doctrine:
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
 
+# If you are not using MySQL, you can comment-out this section
+ez_doctrine_schema:
+    tables:
+        options:
+            charset: '%database_charset%'
+            collate: '%database_collation%'
+
 # Base configuration for Solr, for more options see: https://doc.ezplatform.com/en/latest/guide/search/#solr-bundle
 # Can have several connections used by each eZ Repositories in ezplatform.yml
 ez_search_engine_solr:

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -13,6 +13,7 @@ parameters:
     database_name: '%env(DATABASE_NAME)%'
     database_user: '%env(DATABASE_USER)%'
     database_password: '%env(DATABASE_PASSWORD)%'
+    database_charset: '%env(DATABASE_CHARSET)%'
 
     # Setting for mail system, used by SwiftMailer
     mailer_host: '%env(MAILER_HOST)%'

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -14,6 +14,8 @@ parameters:
     database_user: '%env(DATABASE_USER)%'
     database_password: '%env(DATABASE_PASSWORD)%'
     database_charset: '%env(DATABASE_CHARSET)%'
+    # collation currently has effect on MySQL only
+    database_collation: '%env(DATABASE_COLLATION)%'
 
     # Setting for mail system, used by SwiftMailer
     mailer_host: '%env(MAILER_HOST)%'
@@ -85,6 +87,9 @@ parameters:
     env(RECOMMENDATIONS_LICENSE_KEY):   ~
     env(PUBLIC_SERVER_URI):             ~
 
+    # set here for BC reasons, change them in parameters.yml
+    env(DATABASE_CHARSET): utf8mb4
+    env(DATABASE_COLLATION): utf8mb4_unicode_520_ci
 
     # Compile time handlers
     ## These are defined at compile time, and hence can't be set at runtime using env()

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -15,3 +15,4 @@ parameters:
     env(DATABASE_NAME): ezplatform
     env(DATABASE_USER): root
     env(DATABASE_PASSWORD):
+    env(DATABASE_CHARSET): utf8mb4

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -16,3 +16,4 @@ parameters:
     env(DATABASE_USER): root
     env(DATABASE_PASSWORD):
     env(DATABASE_CHARSET): utf8mb4
+    env(DATABASE_COLLATION): utf8mb4_unicode_520_ci

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "ezsystems/ezplatform-standard-design": "^0.2@dev",
         "ezsystems/ezpublish-kernel": "^7.5@dev",
         "ezsystems/repository-forms": "^2.5@dev",
+        "ezsystems/doctrine-dbal-schema": "^0.1@dev",
         "ezsystems/ezplatform-user": "^1.0@dev",
         "friendsofsymfony/jsrouting-bundle": "^1.6.3",
         "incenteev/composer-parameter-handler": "^2.1.3",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29938](https://jira.ez.no/browse/EZP-29938)
| **Requires** | <ul><li>ezsystems/ezpublish-kernel#2552</li><li>ezsystems/doctrine-dbal-schema#1</li></ul>
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `eZ Platform 2.5 LTS`
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/ezsystems/ezplatform/builds/502501048)
| **Doc needed**     | yes

## TL;DR;

This PR:
- adds `new EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle()` to the list of bundles in `app/AppKernel.php`,
- parametrizes `doctrine.dbal.connections.default.charset` and adds a possibility to provide it in `app/config/parameters.yml` as  `env(DATABASE_CHARSET)` parameter.

To install eZ Platform on PostgreSQL:
- enable the mentioned bundle,
- set `env(DATABASE_CHARSET): utf8` in `parameters.yml`,
- set `env(DATABASE_DRIVER): pdo_pgsql` in `parameters.yml`.

## Summary
This pull request introduces PostgreSQL support by making Legacy Storage database schema installation (import) uniform for all database engines (a.k.a. DBMS, by Doctrine a.k.a. database platforms).

This is done by introducing [`ezsystems/doctrine-dbal-schema` package](https://github.com/ezsystems/doctrine-dbal-schema) which provides (via ezsystems/doctrine-dbal-schema#1) `SchemaBuilder` API which is able in an extensible way, to import database schema into `\Doctrine\DBAL\Schema` object from custom Yaml configuration (schema definition). The format in some places is intentionally quite similar to the one available for Doctrine\ORM.

## Why separate package?

During discovery I haven't found any existing solutions for Doctrine\DBAL\Schema which is PHP API.
Legacy schema definition used by eZ Platform is quite big, so it would be difficult to write and maintain using pure PHP calls.

## Why not just another SQL file?

The reason for that is simple - there is already a lot of them and they're quite redundant with differences solvable by injecting proper strategies for different DBMS-es (implementations of `\Doctrine\DBAL\Platforms\AbstractPlatform`).

The goal here is to achieve uniform import of Schema for all supported database engines both for installation and integration testing purposes.

## What about MySQL?

MySQL still remains the default engine for new installations. The difference is that now it will be installed using uniform Yaml schema definition.

## BC for existing installers for MySQL.

Installing schema from SQL files via custom installer code is still supported. Moreover if custom installer extends `\EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller` and calls parent `importSchema`, there's also no need to do an immediate change - `DbBasedInstaller::importSchema` will install schema using Yaml schema definition provided currently by EzPublishCoreBundle, while custom code can still amend it using traditional SQL.

What is not and never was supported is referencing `vendor/ezsystems/ezpublish-kernel/data/schema.sql` from custom code. This is (and always was) an implementation detail. Of course for BC purposes (just in case) this file will still exist in eZ Platform 2.5 (to be removed in 3.0) but will no longer be maintained, except for bugs.

Required changes to use new SchemaBuilder for installers are done in ezsystems/ezpublish-kernel#2552.

## PostgreSQL support for custom installers

If PostgreSQL support is required for custom installer, it needs to be provided using extensibility points from `SchemaBuilder`.

**TODO**:
- [x] **Before merge:** remove TMP commit.
- [x] Make sure CI won't fail after merging
- [x] Test on MySQL also as schema installation method is common.
- [x] Install and enable `\EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle` from the new package `ezsystems/doctrine-dbal-schema`.
- [x] Parametrize & make configurable database charset as it differs between PostgreSQL and MySQL
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
