### PR TITLE
[Composer] Removed generating GraphQL schema after composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,8 +94,7 @@
             "yarn encore dev"
         ],
         "post-install-cmd": [
-            "@symfony-scripts",
-            "@php bin/console ezplatform:graphql:generate-schema"
+            "@symfony-scripts"
         ],
         "post-update-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
This PR removes automatic execution of `bin/console ezplatform:graphql:generate-schema` after `composer install`.

When there's no database schema (or even database itself in some cased) installed yet (done by `ezplatform:install`) the `composer install` crashes. This is quite common case for people installing for the first time.

I'm aware that it's not possible to use GraphQL without generating this schema, but we need to find alternative solution and right now just document that it's required manual step (maybe installation guide? cc @DominikaK).