### PR TITLE
EZP-30318: [DX] Simplified ezplatform.yml to avoid duplicated config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - TEST_CMD="bin/behat -v --profile=repository-forms --tags=~@broken" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - TEST_CMD="bin/behat -v --profile=behat --tags=~@broken"
     - TEST_CMD="bin/behat --profile=adminui --suite=adminui --no-interaction -vv" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-    - TEST_CMD="bin/behat --profile=adminui --suite=adminui --no-interaction -vv --tags=~@EZP-29291-excluded" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
+    - TEST_CMD="bin/behat --profile=adminui --suite=adminui --no-interaction -vv" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
 
 # test only master (+ Pull requests)
 branches:

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -48,7 +48,7 @@ ezpublish:
         #site_group:
         #    design: main
 
-        admin:
+        admin_group:
             # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
             # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
             # all eng-GB data to other locales first.

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -26,7 +26,8 @@ ezpublish:
             URIElement: 1
 
     # System settings, grouped by default (global), siteaccess and/or siteaccess group
-    # TIP: For multi site install organize shared config in groups, with single site we can set shared config in default
+    # TIP: For multisite installations organize shared config into SiteAccess groups,
+    # for single-site you can place shared config under "default"
     system:
         default:
             # Cache pool service, needs to be different per repository (database) on multi repository install.

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -29,7 +29,7 @@ ezpublish:
     # TIP: For multisite installations organize shared config into SiteAccess groups,
     #      for single-site you can place shared config under "default" and/or "global" for simplicity.
     system:
-        global:
+        default:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
             cache_service_name: '%cache_pool%'
             # These reflect the current installers, complete installation before you change them. For changing var_dir

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -25,11 +25,11 @@ ezpublish:
         match:
             URIElement: 1
 
-    # System settings, grouped by default (global), siteaccess and/or siteaccess group
+    # System settings, read in following order: `default`, <siteaccess-group>, <siteacces>, and `global`
     # TIP: For multisite installations organize shared config into SiteAccess groups,
-    # for single-site you can place shared config under "default"
+    #      for single-site you can place shared config under "default" and/or "global" for simplicity.
     system:
-        default:
+        global:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
             cache_service_name: '%cache_pool%'
             # These reflect the current installers, complete installation before you change them. For changing var_dir

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -27,7 +27,7 @@ ezpublish:
 
     # System settings, read in following order: `default`, <siteaccess-group>, <siteacces>, and `global`
     # TIP: For multisite installations organize shared config into SiteAccess groups,
-    #      for single-site you can place shared config under "default" and/or "global" for simplicity.
+    #      on single-site you can place shared config under "default" for simplicity as shown below.
     system:
         default:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
@@ -52,7 +52,7 @@ ezpublish:
             # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
             # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
             # all eng-GB data to other locales first.
-            # For admin this needs to contain all languages you want to translate content to on the given repository (database).
+            # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
 
         site:

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -55,7 +55,7 @@ ezpublish:
             # For admin this needs to contain all languages you want to translate content to on the given repoistion (database).
             languages: [eng-GB]
 
-        side:
+        site:
             languages: [eng-GB]
 
     url_alias:

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -25,9 +25,10 @@ ezpublish:
         match:
             URIElement: 1
 
-    # System settings, grouped by siteaccess and/or siteaccess group
+    # System settings, grouped by default (global), siteaccess and/or siteaccess group
+    # TIP: For multi site install organize shared config in groups, with single site we can set shared config in default
     system:
-        site_group:
+        default:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
             cache_service_name: '%cache_pool%'
             # These reflect the current installers, complete installation before you change them. For changing var_dir
@@ -47,16 +48,8 @@ ezpublish:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'
 
-        # WARNING: Do not remove or rename this group.
-        admin_group:
-            cache_service_name: '%cache_pool%'
-            var_dir: var/site
-            languages: [eng-GB]
-            content:
-                default_ttl: '%httpcache_default_ttl%'
-            http_cache:
-                purge_servers: ['%purge_server%']
-                varnish_invalidate_token: '%varnish_invalidate_token%'
+        #site_group:
+        #    design: main
 
     url_alias:
         slug_converter:

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -36,10 +36,6 @@ ezpublish:
             # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
             # need to manually modify your database data to reflect this to avoid exceptions.
             var_dir: var/site
-            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
-            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
-            # all eng-GB data to other locales first.
-            languages: [eng-GB]
             content:
                 # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
                 # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
@@ -51,6 +47,16 @@ ezpublish:
 
         #site_group:
         #    design: main
+
+        admin:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
+            # For admin this needs to contain all languages you want to translate content to on the given repoistion (database).
+            languages: [eng-GB]
+
+        side:
+            languages: [eng-GB]
 
     url_alias:
         slug_converter:

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -52,7 +52,7 @@ ezpublish:
             # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
             # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
             # all eng-GB data to other locales first.
-            # For admin this needs to contain all languages you want to translate content to on the given repoistion (database).
+            # For admin this needs to contain all languages you want to translate content to on the given repository (database).
             languages: [eng-GB]
 
         site:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue** | [EZP-30318](https://jira.ez.no/browse/EZP-30318)
| **Resolves**     | <ul><li>[EZP-30305](https://jira.ez.no/browse/EZP-30305) (#373)</li><li>[EZP-29291](https://jira.ez.no/browse/EZP-29291)</li></ul>
| **Bug/Improvement**| yes
| **Target version** | `2.5 (master)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | update for places where `admin_group` is referenced

v2 at some point ended up with lots of duplicate config due to the new admin siteaccess and it's group, however we can rather set `default` here to avoid that.

For demo this will mean we can simplify [from](https://github.com/ezsystems/ezplatform-demo/blob/master/app/config/ezplatform.yml#L42-L93) => to:
```yml
    system:
        default:
            # Cache pool service, needs to be different per repository (database) on multi repository install.
            cache_service_name: '%cache_pool%'
            # These reflect the current installers, complete installation before you change them. For changing var_dir
            # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
            # need to manually modify your database data to reflect this to avoid exceptions.
            var_dir: var/site
            content:
                # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
                # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
                default_ttl: '%httpcache_default_ttl%'
            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
            http_cache:
                purge_servers: ['%purge_server%']

        admin_group:
            languages: [eng-GB, fre-FR, ger-DE, nor-NO]
            # For ee only
            page_builder:
                siteaccess_list: [site, fr, de, no]

        site_group:
            design: main

        fr:
            languages: [fre-FR, eng-GB]
        de:
            languages: [ger-DE, eng-GB]
        no:
            languages: [nor-NO, eng-GB]
```

Bonus: Makes people aware of possibility to set default config.
