### PR TITLE
[Platform.sh]Added support for injecting github token via environment variable

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -77,6 +77,13 @@ hooks:
     # Build hook, done before connected to services, disk is still writable here
     build: |
         set -e
+
+        # Inject GITHUB token if provided. This is handy if you have your own private repos, or need to avoid
+        # github's API rate limit
+        if [ -n "$GITHUB_TOKEN" ]; then
+            composer config github-oauth.github.com $GITHUB_TOKEN
+        fi
+
         rm web/app_dev.php
         composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -78,8 +78,7 @@ hooks:
     build: |
         set -e
 
-        # Inject GITHUB token if provided. This is handy if you have your own private repos, or need to avoid
-        # github's API rate limit
+        # Configure GITHUB token if set. For use if you have own private repos, or to avoid API rate limits.
         if [ -n "$GITHUB_TOKEN" ]; then
             composer config github-oauth.github.com $GITHUB_TOKEN
         fi


### PR DESCRIPTION
This PR makes it handy to let composer use a github token when communicating with github. A github token is needed if you are using private repos on github, or need to avoid githubs rate limit.
