### PR TITLE
[WiP] EZP-30305: Behat tests that use api for content type creation are failing

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -27,6 +27,8 @@ ezpublish:
 
     # System settings, grouped by siteaccess and/or siteaccess group
     system:
+        default:
+            cache_service_name: '%cache_pool%'
         site_group:
             # Cache pool service, needs to be different per repository (database) on multi repository install.
             cache_service_name: '%cache_pool%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30305](https://jira.ez.no/browse/EZP-30305)
| **Bug/Improvement**| yes
| **Target version** | `2.5 (master)`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | maybe?

## Background

Due to #369 default `cache_service_name` changed from Symfony default `cache.app` to `cache.tagaware.filesystem`. It seems that this change is not set for `default` scope.

This PR right now explicitly sets `%cache_pool%` (which is `cache.tagaware.filesystem`) for default scope, This might affect custom projects, so we need to check if there's an alternative (or maybe this is what we actually should do anyway so console commands w/o `--siteaccess` context work properly).

## Steps to reproduce

There's a very simple scenario to test manually:
1. Install clean eZ Platform via CLI
2. Add via Admin panel some Content or Content Type or anything else
3. Install clean eZ Platform via CLI once again
4. Observe cached previous installation in Admin panel :) 

## Alternative

Alternatively we can consider #370 as it does exactly the same thing + more and effort for testing is the same IMHO

**TODO**:
- [x] Check if Travis agrees.
- [x] Explicitly set `cache_service_name` for `default` SA scope.
- [ ] Find out if this works for other forks (even for demo)
- [ ] Investigate if there's better way to do it w/o touching default scope in meta-repository. 