### PR TITLE
[Platform.sh] Changed to 'old' solr config syntax

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -42,9 +42,7 @@ rediscache:
 #    disk: 512
 #    configuration:
 #        configsets:
-#            mainconfig: !include
-#                type: archive
-#                path: "configsets/solr6"
+#            mainconfig: !archive "configsets/solr6"
 #        cores:
 #            collection1:
 #                core_properties: |


### PR DESCRIPTION
The syntax we use for solr config on platform.sh has been revoked by Platform, ref. https://github.com/platformsh/platformsh-docs/commit/f7f79d74223856f4d03a2b71954f1e865aef28ce#diff-3c2bd0d7625d58625747452f091e39af

So introducing the old "!archive" syntax. Without it, you'll simply won't be able to deploy with solr on Platform.sh