### PR TITLE
Update ezplatform-admin-ui-assets version for 2.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/orm": "^2.6.3",
         "ezsystems/ez-support-tools": "~0.2.1@dev",
         "ezsystems/ezplatform-admin-ui": "~1.4.0@dev",
-        "ezsystems/ezplatform-admin-ui-assets": "~3.1.0@dev",
+        "ezsystems/ezplatform-admin-ui-assets": "~3.2.0@dev",
         "ezsystems/ezplatform-admin-ui-modules": "~1.4.0@dev",
         "ezsystems/ezplatform-cron": "~2.0.0@dev",
         "ezsystems/ezplatform-design-engine": "~2.0.0@dev",


### PR DESCRIPTION
Q: Which is the better approach? "~3.2.0@dev" or "^3.1.0@dev"?

Discovered while testing https://github.com/ezsystems/ezplatform-admin-ui/pull/886.