### PR TITLE
Handle symlinks for itemToReplace in eZConfigManager.replace

### DIFF
--- a/ez.webpack.config.manager.js
+++ b/ez.webpack.config.manager.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const findItems = (eZConfig, entryName) => {
     const items = eZConfig.entry[entryName];
 
@@ -9,7 +10,7 @@ const findItems = (eZConfig, entryName) => {
 };
 const replace = ({ eZConfig, entryName, itemToReplace, newItem }) => {
     const items = findItems(eZConfig, entryName);
-    const indexToReplace = items.indexOf(itemToReplace);
+    const indexToReplace = items.indexOf(fs.realpathSync(itemToReplace));
 
     if (indexToReplace < 0) {
         throw new Error(`Couldn't find item "${itemToReplace}" in entry "${entryName}". Please check if there is a typo in the name.`);

--- a/ez.webpack.config.manager.js
+++ b/ez.webpack.config.manager.js
@@ -20,8 +20,9 @@ const replace = ({ eZConfig, entryName, itemToReplace, newItem }) => {
 };
 const remove = ({ eZConfig, entryName, itemsToRemove }) => {
     const items = findItems(eZConfig, entryName);
+    const realPathItemsToRemove = itemsToRemove.map((item) => fs.realpathSync(item));
 
-    eZConfig.entry[entryName] = items.filter((item) => !itemsToRemove.includes(item));
+    eZConfig.entry[entryName] = items.filter((item) => !realPathItemsToRemove.includes(item));
 };
 const add = ({ eZConfig, entryName, newItems }) => {
     const items = findItems(eZConfig, entryName);


### PR DESCRIPTION
I'm using a symlink for `ezplatform-admin-ui` on my local. So `<EZ_ROOT>/vendor/ezsystems/ezplatform-admin-ui` links to `~/Projects/ez/bundles/ezplatform-admin-ui`.

Also I have local `ExtendedAdminUIBundle` bundle, and wanted to replace some items using `ez.config.manager.js`.
`src/ExtendedAdminUIBundle/Resources/encore/ez.config.manager.js`:
```
const path = require('path');

module.exports = (eZConfig, eZConfigManager) => {
    eZConfigManager.replace({
        eZConfig,
        entryName: 'ezplatform-admin-ui-alloyeditor-js',
        itemToReplace: path.resolve(__dirname, '../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js'),
        newItem: path.resolve(__dirname, '../public/js/base-rich-text.js'),
    });
};
```

Without this fix I was unable to run `yarn encore dev` because of:
```
Error: Couldn't find item "<EZ_ROOT>/vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js" in entry "ezplatform-admin-ui-alloyeditor-js".
```

It was happening because `ezplatform-admin-ui-alloyeditor-js` contains realpath, which is `~/Projects/ez/bundles/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js`.