### PR TITLE
EZP-30412: Composer is always using dev for generating encore assets

### DIFF
--- a/bin/compile_assets.sh
+++ b/bin/compile_assets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Script to generate assets using `yarn encore`.
+# It checks SYMFONY_ENV to ensure assets are generated for correct production/development environment.
+
+if [ "${SYMFONY_ENV}" == "dev" ] ; then
+    yarn encore dev
+else
+    yarn encore prod
+fi

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
             "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
             "@php bin/console assetic:dump",
             "yarn install",
-            "yarn encore dev",
+            "bin/compile_assets.sh",
             "@php bin/security-checker security:check"
         ],
         "post-install-cmd": [


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30412

Previously it was always using `dev` assets which was inconvenient for people who were using composer on production environments. This PR changes default behavior to use production ready assets unless `SYMFONY_ENV=dev`.
