### PR TITLE
[Docker]Fixed building of distribution image (for v2.5.0)

### DIFF
--- a/doc/docker/Dockerfile-distribution
+++ b/doc/docker/Dockerfile-distribution
@@ -1,7 +1,12 @@
 # Note : if you set the environment variable COMPOSE_PROJECT_NAME to a non-default value, you'll need to set the
 # DISTRIBUTION_IMAGE build arg too (for instance docker-compose build --no-cache --build-arg DISTRIBUTION_IMAGE=customprojectname_app distribution)
 ARG DISTRIBUTION_IMAGE=docker_app
-FROM ${DISTRIBUTION_IMAGE} as builder
+ARG PHP_IMAGE=ezsystems/php:7.3-v1
+FROM ${DISTRIBUTION_IMAGE} as distrofiles
+
+FROM ${PHP_IMAGE}-node as builder
+
+COPY --from=distrofiles /var/www /var/www
 
 RUN composer config extra.symfony-assets-install hard
 RUN composer run-script post-install-cmd --no-interaction


### PR DESCRIPTION
[These instructions](https://github.com/ezsystems/ezplatform/blame/8e09876e93b79c6bb09b95e459f09a0f8de75964/doc/docker/README.md#L221-L248) do not work on 2.5.0 because yarn is missing when building distribution image.

This PR adds a build stage where yarn is available