### PR TITLE
Move dumping javascript translations to Composer command for compiling assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,6 @@
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
             "@php bin/console assetic:dump",
             "yarn install",
             "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets",
@@ -107,6 +106,9 @@
         ],
         "ezplatform-install": [
             "@php bin/console ezplatform:install clean"
+        ],
+        "ezplatform-compile-assets": [
+            "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets"
         ]
     },
     "config": {


### PR DESCRIPTION
Since compiling assets depends on javascript translations being present, this moves the dumping command from `composer.json` to Composer script.

This makes it possible to run the script by hand if needed (by running newly added script `composer ezplatform-compile-assets`), without risking translations not being present in compiled output, if e.g. web/assets folder was deleted by hand.

Depends on https://github.com/ezsystems/ezplatform-core/pull/8