### PR TITLE
[Travis] Set REST Bundle tests to run directly from its package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,11 @@ branches:
 # list of behat arguments to test
 matrix:
   include:
-    # TMP disable usage of varnish until we figure out segmentation faulty issue on 2.0
-    #- TEST_CMD="--mode=behat --profile=rest --suite=fullJson --tags=~@broken" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml" WEB_HOST="varnish"
     - name: "PHP Unit tests"
       env:
         - TEST_CMD="php bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
         - SYMFONY_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
-    - name: "Kernel Rest fullJson tests"
-      env: BEHAT_OPTS="--mode=behat --profile=rest --suite=fullJson --tags=~@broken --non-strict"
-    - name: "Kernel Rest fullXML tests"
-      env: BEHAT_OPTS="--mode=behat --profile=rest --suite=fullXml --tags=~@broken --non-strict"
-    - name: "Kernel Rest core tests"
+    - name: "Kernel core tests"
       env: BEHAT_OPTS="--mode=behat --profile=core --tags=~@broken"
     - name: "Behat"
       env: BEHAT_OPTS="--mode=behat --profile=behat --tags=~@broken"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ branches:
 # list of behat arguments to test
 matrix:
   include:
-    - name: "PHP Unit tests"
+    - name: "eZ Platform REST Bundle functional tests"
       env:
-        - TEST_CMD="php bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"
+        - TEST_CMD="./bin/.travis/run_rest_tests.sh"
         - SYMFONY_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - name: "Kernel core tests"
       env: BEHAT_OPTS="--mode=behat --profile=core --tags=~@broken"

--- a/bin/.travis/run_rest_tests.sh
+++ b/bin/.travis/run_rest_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Install REST package to get its dev dependencies and use them to run tests
+
+cd ./vendor/ezsystems/ezplatform-rest
+composer install
+php ./vendor/bin/phpunit -c phpunit-integration-rest.xml


### PR DESCRIPTION
This is a follow-up for changes from [EZP-28032](https://jira.ez.no/browse/EZP-28032) merged via #399.

Seems we still have some leftover Kernel REST tests that were executed instead of those from the new package.

The PR changes the way we execute REST functional tests to run them directly from [`ezplatform-rest`](https://github.com/ezsystems/ezplatform-rest) package prior installing its dev dependencies.
The reason we should do it is simple - those tests were written for the vendor packages (like PHPUnit) defined by the package `composer.json` - not the one from the meta-repository.

This PR also drops REST behat tests as they're all covered by the functional tests of [eZ Platform REST Bundle](https://github.com/ezsystems/ezplatform-rest).

**TODO**:
- [ ] Confirm that tests executed in a new way can access eZ Platform instance running inside docker container.
- [ ] Double check that all dropped REST behat tests are covered by the functional tests.