### PR TITLE
delete unneded blank space at the end of line

### DIFF
--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -39,7 +39,7 @@ parameters:
     # Cache DSN, see app/config/services/cache.yml for examples:
     cache_dsn: '%env(CACHE_DSN)%'
     
-    # Cache namespace prefix for use with Redis/Memcached, 'ez' by default. 
+    # Cache namespace prefix for use with Redis/Memcached, 'ez' by default.
     # For further info incl alternatives for "blue/green deployment" and multi repo installs, see: app/config/cache_pool/*.yml
     cache_namespace: '%env(CACHE_NAMESPACE)%'
 


### PR DESCRIPTION
No big deal here. When adding something to my default_parameters.yml in my project, looks the cs inspector in the IDE and so, this blank space is deleted. I noticed this when reviewing the PR i was working on. 

But still, if we have it deleted here, it won't popup in the future to more people. 

Let me know if you want a ticket for this. 

ping @lserwatka @andrerom @adamwojs 