### PR TITLE
Use old Docker-Selenium container

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ PHP_IMAGE=ezsystems/php:7.3-v1
 PHP_IMAGE_DEV=ezsystems/php:7.3-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
-SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59
+SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-oxygen
 REDIS_IMAGE=healthcheck/redis
 
 APP_DOCKER_FILE=doc/docker/Dockerfile-app


### PR DESCRIPTION
All Travis build are currently failing, unable to login:

Example:
https://travis-ci.org/ezsystems/ezplatform/builds/542009341

This is caused by yesterday's release of Selenium Docker image, which upgraded Chrome version (see: https://github.com/SeleniumHQ/docker-selenium/issues/922 )

The workaround proposed in https://github.com/minkphp/MinkSelenium2Driver/issues/293#issuecomment-499458269 does not work for us, so the only option for me is keep using the latest working version until we figure this out.