### PR TITLE
EZP-30642: Added Travis dedicated error log

### DIFF
--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -17,3 +17,10 @@ swiftmailer:
 
 assetic:
     use_controller: false
+
+monolog:
+    handlers:
+        travis:
+            type: stream
+            path: "%kernel.logs_dir%/travis_test.log"
+            level: error


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30642

Added a dedicated Travis log from which we will display errors on Travis (added in https://github.com/ezsystems/ezplatform-admin-ui/pull/1012/files)