### PR TITLE
[Travis] Increase Composer memory limit to 4g

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ COMPOSE_DIR=.
 
 # You'll need to adjust this for Windows and XDB Linux systems: https://getcomposer.org/doc/03-cli.md#composer-home
 COMPOSER_HOME=~/.composer
-COMPOSER_MEMORY_LIMIT=2G
+COMPOSER_MEMORY_LIMIT=4G
 
 ## Docker images (name and version)
 PHP_IMAGE=ezsystems/php:7.3-v1


### PR DESCRIPTION
Increasing COMPOSER_MEMORY_LIMIT to fix issues with Composer on Travis. Examples:
https://travis-ci.org/ezsystems/repository-forms/jobs/544973712#L465
https://travis-ci.org/ezsystems/ezplatform-admin-ui/jobs/544726667

I've tried increasing the minimum supported version of our packages, but the result is not really worth it:
```
[457.1MiB/144.71s] Memory usage: 457.09MiB (peak: 2143.09MiB), time: 144.71s - before
[457.1MiB/152.79s] Memory usage: 457.07MiB (peak: 2122.2MiB), time: 152.79s - after
```
Value is set to the same as in PageBuilder.