### PR TITLE
[Composer] Use extra.symfony.require to restrict versions of symfony/*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,4 @@
 {
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "name": "ezsystems/ezplatform",
     "description": "eZ Platform distribution",
     "homepage": "https://github.com/ezsystems/ezplatform",
@@ -37,32 +35,32 @@
         "php-http/guzzle6-adapter": "^2.0",
         "sensio/framework-extra-bundle": "^5.1",
         "sensiolabs/security-checker": "^5.0",
-        "symfony/asset": "^4.3",
-        "symfony/cache": "^4.3",
-        "symfony/console": "^4.3",
-        "symfony/dotenv": "^4.3",
-        "symfony/expression-language": "^4.3",
+        "symfony/asset": "*",
+        "symfony/cache": "*",
+        "symfony/console": "*",
+        "symfony/dotenv": "*",
+        "symfony/expression-language": "*",
         "symfony/flex": "^1.1",
-        "symfony/form": "^4.3",
-        "symfony/framework-bundle": "^4.3",
+        "symfony/form": "*",
+        "symfony/framework-bundle": "*",
         "symfony/monolog-bundle": "^3.1",
         "symfony/orm-pack": "^1.0",
-        "symfony/process": "^4.3",
-        "symfony/proxy-manager-bridge": "^4.3",
-        "symfony/security-bundle": "^4.3",
+        "symfony/process": "*",
+        "symfony/proxy-manager-bridge": "*",
+        "symfony/security-bundle": "*",
         "symfony/serializer-pack": "^1.0",
         "symfony/swiftmailer-bundle": "^3.1",
-        "symfony/translation": "^4.3",
+        "symfony/translation": "*",
         "symfony/thanks": "^1.1",
-        "symfony/twig-bundle": "^4.3",
-        "symfony/validator": "^4.3",
-        "symfony/web-link": "^4.3",
+        "symfony/twig-bundle": "*",
+        "symfony/validator": "*",
+        "symfony/web-link": "*",
         "symfony/webpack-encore-bundle": "^1.4",
-        "symfony/yaml": "^4.3"
+        "symfony/yaml": "*"
     },
     "require-dev": {
         "behat/behat": "^3.5",
-        "behat/mink": "^1.7",
+        "behat/mink": "^1.7@dev",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.3",
@@ -74,7 +72,7 @@
         "symfony/debug-pack": "^1.0",
         "symfony/maker-bundle": "^1.0",
         "symfony/test-pack": "^1.0",
-        "symfony/web-server-bundle": "^4.2",
+        "symfony/web-server-bundle": "*",
         "phpunit/phpunit": "^8.2"
     },
     "conflict": {
@@ -127,7 +125,8 @@
     },
     "extra": {
         "symfony": {
-            "allow-contrib": true
+            "allow-contrib": true,
+            "require": "^4.3.2"
         },
         "branch-alias": {
             "dev-master": "3.0.x-dev"


### PR DESCRIPTION
This PR takes advantage of Flex mechanisms that allows to reduce memory usage. Huge thanks to @adamwojs who made me aware that this exists 😉 🍻 

Most important point (measured with `composer update --profile`):
Before: `[909.1MiB/626.18s] Memory usage: 909.06MiB (peak: 4176.04MiB), time: 626.18s`
After: `[238.2MiB/131.53s] Memory usage: 238.17MiB (peak: 309.66MiB), time: 131.53s`

#### Pros:
1) More than 10x improvement when it comes to peak memory usage 💥 
2) Possibly less maintenance when it comes to upgrading Symfony packages

#### Cons:
1) We need to use `behat/mink` in `dev-master` version. It's a `dev` dependency.

#### A bit more about this:
1) This PR uses an sort-of* undocumented Flex feature, introduced in https://github.com/symfony/flex/pull/409
Core sentence:
```
PR now handles a new SYMFONY_REQUIRE env var that should contain a version constraint that will apply to all packages replaced by symfony/symfony.
```

I've replaced all version constraints for packages listed under this section: https://github.com/symfony/symfony/blob/4.4/composer.json#L37 with `*` and applied a global constraint: `^4.3.2`

*They use it themselves in the skeleton: https://github.com/symfony/skeleton/pull/93

2) The Mink issue:
By using a global requirement for Symfony: ^4.3.2, we are also restricting `symfony/css-selector`. This is a package required by Mink and there is only one version that supports it - `dev-master`. There are hopes that a new version with support for Symfony 4 will be released, but currently it's blocked (see https://github.com/minkphp/Mink/issues/757 for more details).

For me using dev-master version of Mink is not an issue right now, because it's a dev dependency (and the tests should be working with it with it). The question is how will we approach this when tagging releases:
release a version with `behat/mink:dev-master` version in composer.lock or revert to the old approach that will allow us to use symfony/css-selector:^3.0 (and therefore Mink v1.7.1).

#### Additional
I've removed this section:
```
    "minimum-stability": "dev",		
    "prefer-stable": true,
```
Reasons:
1) this should make Composer's job easier, as it doesn't have to check for dev versions for all packages
2) this is meta repository, I think we should be using dev dependencies only when we're completely aware of it (by requiring it with `@dev` flag)
3) it allows us to install dev-master of ezsystems/behat-screenshot-image-driver-cloudinary

Any opinions are welcome, I really like the performance improvement that comes with this, but not sure how we should handle a dev-master dependency when it comes to tagging a release.