### PR TITLE
Enable CSRF token in login form by default

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,7 @@ security:
             ezpublish_rest_session: ~
             form_login:
                 require_previous_session: false
+                csrf_token_generator: security.csrf.token_manager
             logout: ~
 
         main:


### PR DESCRIPTION
Ref public security advisory [EZSA-2019-004: CSRF token in login form is disabled by default](https://share.ez.no/community-project/security-advisories/ezsa-2019-004-csrf-token-in-login-form-is-disabled-by-default)

This brings https://github.com/ezsystems/ezplatform/commit/c899d044cc64c1b3955572fa4d4b9066d8dcc5fc into master. It was not tested in 3.0 by QA, so bringing it up for review here.