### PR TITLE
EZP-30656: render_esi is not configured by default

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -83,6 +83,8 @@ framework:
     translator: { fallback: '%locale_fallback%' }
     validation: { enable_annotations: true }
     default_locale: '%locale_fallback%'
+    esi: true
+    fragments: true
     session:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         # if handler_id set to null will use default session handler from php.ini

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -11,7 +11,5 @@ framework:
         cookie_secure: auto
         cookie_samesite: lax
 
-    #esi: true
-    #fragments: true
     php_errors:
         log: true


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30656

# Description
I intentionally moved ESI configuration to `ezplatform.yaml` to indicate that it's used by eZ Platform.