### PR TITLE
EZP-30723:Mailing does not work on Platform.sh

### DIFF
--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -36,6 +36,11 @@ foreach ($relationships['database'] as $endpoint) {
     $container->setParameter('cluster_database_name', 'cluster');
 }
 
+// If mailer_host has default value, then set it to platform.sh' default instead
+if ($container->getParameter('mailer_host') === '127.0.0.1') {
+    $container->setParameter('mailer_host', getenv('PLATFORM_SMTP_HOST'));
+}
+
 // PLATFORMSH_DFS_NFS_PATH is different compared to DFS_NFS_PATH in the sense that it is relative to ezplatform dir
 // DFS_NFS_PATH is an absolute path
 if ($dfsNfsPath = getenv('PLATFORMSH_DFS_NFS_PATH')) {


### PR DESCRIPTION
We don't set swiftmailer config correct on Platform.sh

**IMPORTANT**
When merging this to 2.4 and later, the following change is needed:
```patch
-if ($container->getParameter('mailer_host') === '127.0.0.1') {
+if ($container->resolveEnvPlaceholders($container->getParameter('mailer_host'), true) === '127.0.0.1') {

```