### PR TITLE
[Composer] Removed min-stability and prefer-stable sections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,4 @@
 {
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "name": "ezsystems/ezplatform",
     "description": "eZ Platform distribution",
     "homepage": "https://github.com/ezsystems/ezplatform",


### PR DESCRIPTION
Removing minimum-stability and prefer-stable section from this composer.json , as currently beta versions of our packages are installed when doing composer install on master. 

Proof: https://travis-ci.org/ezsystems/ezplatform/jobs/553990882