### PR TITLE
EZP-30667: Made database charset and collation configurable via dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -48,7 +48,8 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 DATABASE_HOST=db
 DATABASE_PORT=3306
-DATABASE_DRIVER=mysql
+DATABASE_PLATFORM=mysql
+DATABASE_DRIVER=pdo_mysql
 
 # Doctrine DBAL Schema
 # set here for BC reasons, change them in parameters.yml
@@ -70,7 +71,7 @@ APP_SECRET=ff6dc61a329dc96652bb092ec58981f7
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Configure your db driver and server_version in config/packages/doctrine.yaml
-DATABASE_URL=${DATABASE_DRIVER}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+DATABASE_URL=${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -4,17 +4,17 @@ parameters:
     # environment variables are not available yet.
     # You should not need to change this value.
     env(DATABASE_URL): ''
+    env(DATABASE_DRIVER): ''
+    database_driver: '%env(DATABASE_DRIVER)%'
 
 doctrine:
     dbal:
         # configure these for your database server
-        driver: 'pdo_mysql'
-        server_version: '5.7'
-        charset: utf8mb4
+        driver: '%database_driver%'
+        charset: '%database_charset%'
         default_table_options:
-            charset: utf8mb4
-            collate: utf8mb4_unicode_ci
-
+            charset: '%database_charset%'
+            collate: '%database_collation%'
         url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: true


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30667

This is a followup fixing issue mentioned in https://github.com/ezsystems/ezplatform/pull/428#pullrequestreview-257949806

It changes `DATABASE_DRIVER` env meaning - it will now define driver used by doctrine to connect to the database i.e. `pdo_mysql`. `DATABASE_PLATFORM` now handles prefix used to distinguish to which DB platform you are connecting to i.e. `mysql`, `pgsql`.