### PR TITLE
Enable CSRF token in login form by default

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -24,6 +24,7 @@ security:
             ezpublish_rest_session: ~
             form_login:
                 require_previous_session: false
+                csrf_token_generator: security.csrf.token_manager
             logout: ~
 
         main:


### PR DESCRIPTION
Enables CSRF token in login forms by default. This is a publicly known security issue which isn't merged yet due to a problem with kernel tests, see separate PR for that. Users have been recommended to enable it.
https://share.ez.no/community-project/security-advisories/ezsa-2019-004-csrf-token-in-login-form-is-disabled-by-default

⚠ The kernel SessionTest will fail here, but passes if https://github.com/ezsystems/ezpublish-kernel/pull/2693 is merged.