### PR TITLE
EZP-30717: Added default pagination limit for admin_group

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -74,6 +74,9 @@ ezpublish:
 
         site:
             languages: [eng-GB]
+        admin_group:
+            pagination:
+                user_settings_limit: 10
 
     url_alias:
         slug_converter:


### PR DESCRIPTION
This is one of 2 PR's that moves the default value of `pagination.user_setting_limit` for `admin_group` from bundle defaults to meta repos. This is done to improve developers experience and avoid misunderstandings described here :  https://jira.ez.no/browse/EZP-30717 .

orginal ticket : https://jira.ez.no/browse/EZP-30553