### PR TITLE
[Behat] Increased success notification timeout in Behat env

### DIFF
--- a/app/config/ezplatform_behat.yml
+++ b/app/config/ezplatform_behat.yml
@@ -19,4 +19,4 @@ ez_platform_standard_design:
     override_kernel_templates: false
 
 parameters:
-    ezsettings.default.notifications.success.timeout: 10000
+    ezsettings.default.notifications.success.timeout: 20000


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30801

I've investigated that error and I didn't find anything wrong with maplocation field type, but verified that in Chrome with throttling enabled the time between clicking "Publish" and displaying the notification can be quite long. 

We're already waiting for the notification to appear for 20 seconds (https://github.com/ezsystems/ezplatform-admin-ui/blob/master/src/lib/Behat/PageElement/Notification.php#L36), it makes sense to me to display it for the same amount.

Note to self: this required careful merging upstream, as the config is in other place in 3.0.