### PR TITLE
EZP-30804: Removed env use from session handler configuration

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -5,10 +5,10 @@ parameters:
     search_engine: '%env(SEARCH_ENGINE)%'
 
     ## Session handler, by default set to file based (instead of ~) in order to be able to use %ezplatform.session.save_path%
-    ezplatform.session.handler_id: '%env(SESSION_HANDLER_ID)%'
+    ezplatform.session.handler_id: session.handler.native_file
 
     # Session save path as used by symfony session handlers (eg. used for dsn with redis)
-    ezplatform.session.save_path: '%env(SESSION_SAVE_PATH)%'
+    ezplatform.session.save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
 
     # Settings for Cache pool, to change add own cache service and optionally inject own arguments
     # predefined pools: see symfony config and the optional pools in app/config/cache_pool/

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -7,7 +7,6 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: ~
         cookie_secure: auto
         cookie_samesite: lax
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30804

# Description

It removes `handler_id` setting from `framework.yaml` so that configuration from `ezplatform.yaml` is not overrode. Also I made a mistake and used envs to configure this setting but this is not possible in this place. This wasn't visible because of `framework.yaml` taking precedence.

I left `SESSION_HANDLER_ID` and `SESSION_SAVE_PATH` in `.env` intentionally as it will be used by Platform.sh once we bring back support for it in 3.0.