### PR TITLE
[Behat] Marked Behat env as test

### DIFF
--- a/config/packages/behat/framework.yaml
+++ b/config/packages/behat/framework.yaml
@@ -1,0 +1,2 @@
+framework:
+    test: true


### PR DESCRIPTION
Enabling https://symfony.com/doc/current/reference/configuration/framework.html#test so that Symfony2Extension is able to get private services from the container.

What happens right now:
Hooks Context has the logger service injected - https://github.com/ezsystems/BehatBundle/blob/master/src/lib/Browser/Context/Hooks.php#L30
This is causing the tests to fail with error:
```
 [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                                                                                                               

  The "logger" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.  
```
Source: https://travis-ci.com/ezsystems/ezplatform-form-builder/jobs/222764450

It happens because Symfony2Extension tries to get the service directly from the container (https://github.com/Behat/Symfony2Extension/blob/master/src/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolver.php#L73) and if test setting is disabled it's not using the `test.service_container` container.

Enabling it fixes the issue (and it makes sense that `behat` env is treated as a test one)

