### PR TITLE
[Platform.sh] Revise bundled config & inline doc

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,7 +47,7 @@ variables:
         # If you change to "dev" remove "--no-dev" from `composer install` command.
         SYMFONY_ENV: prod
         # Uncomment if you want to use DFS clustering:
-        # NOTE: Recommended on PE Dedicated cluster setup. Required if using legacy-bridge.
+        # NOTE: Recommended on PE Dedicated cluster setup. Required if using legacy-bridge on PE dedicated cluster setup.
         #PLATFORMSH_DFS_NFS_PATH: 'dfsdata'
 
 # The configuration of app when it is exposed to the web.
@@ -92,7 +92,7 @@ mounts:
 #    'src/AppBundle/MigrationVersions/References':
 #        source: local
 #        source_path: MigrationVersionsReferences
-# Uncomment if you want to use DFS clustering, required if using legacy-bridge.
+# Uncomment if you want to use DFS clustering, required if using legacy-bridge on PE dedicated cluster setup.
 #    'dfsdata':
 #        # Platform.sh Staff: This MUST be shared on cluster, all others SHOULD be local for performance reasons
 #        source: local

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -94,7 +94,8 @@ mounts:
 #        source_path: MigrationVersionsReferences
 # Uncomment if you want to use DFS clustering, required if using legacy-bridge.
 #    'dfsdata':
-#        source: shared
+#        # Platform.sh Staff: This MUST be shared on cluster, all others SHOULD be local for performance reasons
+#        source: local
 #        source_path: dfsdata
 
 # The hooks that will be performed when the package is deployed.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,8 +1,9 @@
 # This file describes an application. You can have multiple applications
 # in the same project.
 
-# Please see doc/platformsh/README.md and doc/platformsh/INSTALL.md
-# NB: Clustered eZ Platform setups are not tested and are likely to have issues.
+# Please see doc/platformsh/README.md and doc/platformsh/INSTALL.md for eZ specific getting started instructions.
+# Full documentation: https://docs.platform.sh
+# Requirements: https://doc.ezplatform.com/en/2.5/getting_started/requirements/#ez-platform-cloud-requirements-and-setup
 
 # The name of this app. Must be unique within a project.
 name: app
@@ -13,8 +14,10 @@ dependencies:
 
 # The type of the application to build.
 type: php:7.3
+
 build:
     # "none" means we're running composer manually, see build hook
+    # We currently need to do this because of the need to install newer version of Node.js
     flavor: "none"
 
 # The relationships of the application with services or other applications.
@@ -26,7 +29,7 @@ relationships:
     # Uncomment if you want to store dfs tables in a separate database:
     #dfs_database: 'mysqldb:dfs'
     rediscache: 'rediscache:redis'
-    # If you wish to have a separate Redis instance for sessions, uncomment
+    # [Recommended] To have an isolated & persisted Redis instance for sessions, uncomment
     # this relationship and the corresponding service in .platform/services.yaml
     #redissession: 'redissession:redis'
     # If you wish to use solr, uncomment this relationship and the corresponding service in .platform/services.yaml
@@ -40,9 +43,11 @@ variables:
         # We disable Symfony Proxy, as we rather use Varnish
         SYMFONY_HTTP_CACHE: 0
         SYMFONY_TRUSTED_PROXIES: "TRUST_REMOTE"
-        # Change this if you use a different env then "prod", if you change this to "dev" remove "--no-dev" in build step
+        # Change this if you use a different env then "prod"
+        # If you change to "dev" remove "--no-dev" from `composer install` command.
         SYMFONY_ENV: prod
         # Uncomment if you want to use DFS clustering:
+        # NOTE: Recommended on PE Dedicated cluster setup. Required if using legacy-bridge.
         #PLATFORMSH_DFS_NFS_PATH: 'dfsdata'
 
 # The configuration of app when it is exposed to the web.
@@ -65,6 +70,8 @@ disk: 3072
 
 # The mounts that will be performed when the package is deployed.
 mounts:
+# PE Cluster Note: By default will set all to shared, so if moving to PE dedicated cluster you should ask platform.sh
+# Support to make sure at least cache + logs is local, while you can let web/var be shared if you prefer that over DFS.
     'var/cache':
         source: local
         source_path: cache
@@ -85,7 +92,7 @@ mounts:
 #    'src/AppBundle/MigrationVersions/References':
 #        source: local
 #        source_path: MigrationVersionsReferences
-# Uncomment if you want to use DFS clustering, WARNING: Needs to be shared, contact Platform.sh support to set this up
+# Uncomment if you want to use DFS clustering, required if using legacy-bridge.
 #    'dfsdata':
 #        source: shared
 #        source_path: dfsdata
@@ -96,6 +103,7 @@ hooks:
     build: |
         set -e
 
+        # Install newer version of Node.js, as current default (v6LTS) does not play well with WebpackEncore
         unset NPM_CONFIG_PREFIX
         curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | dash
         export NVM_DIR="$HOME/.nvm"
@@ -103,13 +111,15 @@ hooks:
         nvm current
         nvm install 10.15.3
 
-        # Configure GITHUB token if set. For use if you have own private repos, or to avoid API rate limits.
-        if [ -n "$GITHUB_TOKEN" ]; then
-            composer config github-oauth.github.com $GITHUB_TOKEN
+        if ["$COMPOSER_AUTH" == ""]; then
+            echo "TIP: If you need to authenticate against Github/Gitlab/updates.ez.no, use COMPOSER_AUTH env variable"
+            echo "See: https://docs.platform.sh/tutorials/composer-auth.html#set-the-envcomposerauth-project-variable"
         fi
 
-        rm web/app_dev.php
         composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+
+        # Generic cleanup to remove files we don't want to be deployed to prod (you don't need this for "dev" ENV)
+        rm web/app_dev.php
 
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
@@ -127,15 +137,23 @@ hooks:
             touch web/var/.platform.installed
         fi
 
-        # Now that mounts are available, clear class/container cache. E.g. in case of interface changes on lazy proxies
-        rm -Rf var/cache/$SYMFONY_ENV/*.*
+        # Now that mounts are available, clear cache on mount.
+        # NB! Skip on PE Cluster setup using e.g. "if [$PLATFORM_BRANCH" != 'production']; then" & get p.sh to enable this on internal per node "pre_start" hook
+        ./bin/platformsh/pre_start-per_node-clear_cache.sh
 
-        # With that done, make sure to clear + warmup all remaining caches to take proper env variables into account
-        bin/console cache:clear
+        # If you also need to clear redis cache on every deploy, you can either use this command or redis-cli
+        # Normally this should only be needed if cached data structures changes (upgrades), or you change data via sql (e.g. restore backup)
+        ##php bin/console cache:pool:clear cache.redis
 
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
-        ##bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
-        ##bin/console kaliop:migration:migrate --no-interaction --no-debug
+        ##php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+        ##php bin/console kaliop:migration:migrate --no-interaction --no-debug
+
+        # When using Solr, there are two cases where you'll need to rebuild indexes:
+        # - When Solr / search configuration change
+        # - On database import/restore
+        # So in development it might be convenient to rebuild indexes, slowing down deploy time
+        ##php bin/console ezplatform:reindex --processes=auto
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     #post_deploy: |

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -17,7 +17,7 @@ type: php:7.3
 
 build:
     # "none" means we're running composer manually, see build hook
-    # We currently need to do this because of the need to install newer version of Node.js
+    # We currently need to do this to install newer version of Node.js
     flavor: "none"
 
 # The relationships of the application with services or other applications.
@@ -29,7 +29,7 @@ relationships:
     # Uncomment if you want to store dfs tables in a separate database:
     #dfs_database: 'mysqldb:dfs'
     rediscache: 'rediscache:redis'
-    # [Recommended] To have an isolated & persisted Redis instance for sessions, uncomment
+    # [Recommended] To have an isolated and persisted Redis instance for sessions, uncomment
     # this relationship and the corresponding service in .platform/services.yaml
     #redissession: 'redissession:redis'
     # If you wish to use solr, uncomment this relationship and the corresponding service in .platform/services.yaml
@@ -43,11 +43,11 @@ variables:
         # We disable Symfony Proxy, as we rather use Varnish
         SYMFONY_HTTP_CACHE: 0
         SYMFONY_TRUSTED_PROXIES: "TRUST_REMOTE"
-        # Change this if you use a different env then "prod"
-        # If you change to "dev" remove "--no-dev" from `composer install` command.
+        # Change this if you use a different env than "prod"
+        # If you change to "dev" remove "--no-dev" from the `composer install` command.
         SYMFONY_ENV: prod
         # Uncomment if you want to use DFS clustering:
-        # NOTE: Recommended on PE Dedicated cluster setup. Required if using legacy-bridge on PE dedicated cluster setup.
+        # NOTE: Recommended on PE Dedicated cluster setup. Required if using Legacy Bridge on PE dedicated cluster setup.
         #PLATFORMSH_DFS_NFS_PATH: 'dfsdata'
 
 # The configuration of app when it is exposed to the web.
@@ -71,7 +71,7 @@ disk: 3072
 # The mounts that will be performed when the package is deployed.
 mounts:
 # PE Cluster Note: By default will set all to shared, so if moving to PE dedicated cluster you should ask platform.sh
-# Support to make sure at least cache + logs is local, while you can let web/var be shared if you prefer that over DFS.
+# Support to make sure at least cache + logs are local, while you can let web/var be shared if you prefer that over DFS.
     'var/cache':
         source: local
         source_path: cache
@@ -92,7 +92,7 @@ mounts:
 #    'src/AppBundle/MigrationVersions/References':
 #        source: local
 #        source_path: MigrationVersionsReferences
-# Uncomment if you want to use DFS clustering, required if using legacy-bridge on PE dedicated cluster setup.
+# Uncomment if you want to use DFS clustering, required if using Legacy Bridge on PE dedicated cluster setup.
 #    'dfsdata':
 #        # Platform.sh Staff: This MUST be shared on cluster, all others SHOULD be local for performance reasons
 #        source: local
@@ -139,10 +139,10 @@ hooks:
         fi
 
         # Now that mounts are available, clear cache on mount.
-        # NB! Skip on PE Cluster setup using e.g. "if [$PLATFORM_BRANCH" != 'production']; then" & get p.sh to enable this on internal per node "pre_start" hook
+        # Note: Skip on PE Cluster setup using e.g. "if [$PLATFORM_BRANCH" != 'production']; then" & get p.sh to enable this on internal per node "pre_start" hook
         ./bin/platformsh/pre_start-per_node-clear_cache.sh
 
-        # If you also need to clear redis cache on every deploy, you can either use this command or redis-cli
+        # If you also need to clear Redis cache on every deploy, you can either use this command or redis-cli
         # Normally this should only be needed if cached data structures changes (upgrades), or you change data via sql (e.g. restore backup)
         ##php bin/console cache:pool:clear cache.redis
 
@@ -151,7 +151,7 @@ hooks:
         ##php bin/console kaliop:migration:migrate --no-interaction --no-debug
 
         # When using Solr, there are two cases where you'll need to rebuild indexes:
-        # - When Solr / search configuration change
+        # - When Solr / search configuration changes
         # - On database import/restore
         # So in development it might be convenient to rebuild indexes, slowing down deploy time
         ##php bin/console ezplatform:reindex --processes=auto

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,10 +1,10 @@
-# Default settings in order to setup eZ Platform demo install on Platform.sh dev instances
+# Default settings in order to set up eZ Platform demo install on Platform.sh dev instances
 #
-# NB: Like on own servers, make sure to tune Redis/Solr/Varnish/Mysql memory/disk size for your installation to avoid issues.
+# Note: Like on own servers, make sure to tune Redis/Solr/Varnish/MySQL memory/disk size for your installation to avoid issues.
 #     Reach out to platform.sh support to get help on this and insight into your disk/memory usage.
 
 mysqldb:
-    # NB! If you change this also change DATABASE_VERSION, as used by "doctrine.dbal.server_version" in config.yml.
+    # Note: If you change this also change DATABASE_VERSION, as used by "doctrine.dbal.server_version" in config.yml.
     type: mysql:10.2
     # Version 10.1 might be a better option when running Legacy Bridge
     # For more information see https://doc.ezplatform.com/en/2.1/getting_started/requirements_and_system_configuration/#supported-setups
@@ -28,7 +28,7 @@ mysqldb:
 # For use by Symfony Cache (used by eZ Platform SPI Persistence Cache)
 rediscache:
     type: 'redis:5.0'
-    # For cache you might need to increase the size of your plan if your install sizeable amount of content.
+    # For cache you might need to increase the size of your plan if your installation has a sizeable amount of content.
     # Check with platform.sh staff if in doubt on this, and if it would make sense to configure larger redis size here.
     # size: L
     configuration:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -48,8 +48,8 @@ rediscache:
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
 #    type: redis-persistent:5.0
- # Disk size should be bigger than redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
- # The memory given to redis is dependend on your plan and "size: ". Adjust "disk: " accordingly
+ # Disk size should be bigger than Redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
+ # The memory given to Redis depends on your plan and "size: ". Adjust "disk: " accordingly.
  #    disk: 512
 #    configuration:
 #        maxmemory_policy: allkeys-lru

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -29,7 +29,7 @@ mysqldb:
 rediscache:
     type: 'redis:5.0'
     configuration:
-        # For cache eZ Platform 2.5+ RedisTagAwareAdapter requries one of the 'volatile-lru' eviction policies
+        # For cache eZ Platform 2.5+ RedisTagAwareAdapter requries one of the 'volatile-*' eviction policies
         # https://docs.platform.sh/configuration/services/redis.html#eviction-policy
         # https://doc.ezplatform.com/en/2.5/getting_started/requirements/
         maxmemory_policy: volatile-lru

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -28,6 +28,9 @@ mysqldb:
 # For use by Symfony Cache (used by eZ Platform SPI Persistence Cache)
 rediscache:
     type: 'redis:5.0'
+    # For cache you might need to increase the size of your plan if your install sizeable amount of content.
+    # Check with platform.sh staff if in doubt on this, and if it would make sense to configure larger redis size here.
+    # size: L
     configuration:
         # For cache eZ Platform 2.5+ RedisTagAwareAdapter requries one of the 'volatile-*' eviction policies
         # https://docs.platform.sh/configuration/services/redis.html#eviction-policy

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -48,7 +48,9 @@ rediscache:
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
 #    type: redis-persistent:5.0
-#    disk: 512
+ # Disk size should be bigger than redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
+ # The memory given to redis is dependend on your plan and "size: ". Adjust "disk: " accordingly
+ #    disk: 512
 #    configuration:
 #        maxmemory_policy: allkeys-lru
 

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -48,9 +48,9 @@ rediscache:
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
 #    type: redis-persistent:5.0
- # Disk size should be bigger than Redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
- # The memory given to Redis depends on your plan and "size: ". Adjust "disk: " accordingly.
- #    disk: 512
+# Disk size should be bigger than Redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
+# The memory given to Redis depends on your plan and "size: ". Adjust "disk: " accordingly.
+#    disk: 512
 #    configuration:
 #        maxmemory_policy: allkeys-lru
 

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,4 +1,10 @@
+# Default settings in order to setup eZ Platform demo install on Platform.sh dev instances
+#
+# NB: Like on own servers, make sure to tune Redis/Solr/Varnish/Mysql memory/disk size for your installation to avoid issues.
+#     Reach out to platform.sh support to get help on this and insight into your disk/memory usage.
+
 mysqldb:
+    # NB! If you change this also change DATABASE_VERSION, as used by "doctrine.dbal.server_version" in config.yml.
     type: mysql:10.2
     # Version 10.1 might be a better option when running Legacy Bridge
     # For more information see https://doc.ezplatform.com/en/2.1/getting_started/requirements_and_system_configuration/#supported-setups

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -42,7 +42,7 @@ rediscache:
 #redissession:
 #    type: 'redis:5.0'
 #    configuration:
-#        maxmemory_policy: allkeys-ttl
+#        maxmemory_policy: allkeys-lru
 #
 # Alternatively if you have a requirement that sessions are persisted across server/redis restarts,
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
@@ -50,7 +50,7 @@ rediscache:
 #    type: redis-persistent:5.0
 #    disk: 512
 #    configuration:
-#        maxmemory_policy: allkeys-ttl
+#        maxmemory_policy: allkeys-lru
 
 # If you wish to use solr, uncomment this service and the corresponding relationship in .platform.app.yaml.
 # Also, you need to generate the config using:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -27,18 +27,27 @@ mysqldb:
 
 # For use by Symfony Cache (used by eZ Platform SPI Persistence Cache)
 rediscache:
-    type: 'redis:3.2'
+    type: 'redis:5.0'
+    configuration:
+        # For cache eZ Platform 2.5+ RedisTagAwareAdapter requries one of the 'volatile-lru' eviction policies
+        # https://docs.platform.sh/configuration/services/redis.html#eviction-policy
+        # https://doc.ezplatform.com/en/2.5/getting_started/requirements/
+        maxmemory_policy: volatile-lru
 
 # If you wish to have a separate Redis instance for sessions, uncomment
 # this service and the corresponding relationship in .platform.app.yaml.
 #redissession:
-#    type: 'redis:3.2'
+#    type: 'redis:5.0'
+#    configuration:
+#        maxmemory_policy: allkeys-ttl
 #
 # Alternatively if you have a requirement that sessions are persisted across server/redis restarts,
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
-#    type: redis-persistent:3.2
+#    type: redis-persistent:5.0
 #    disk: 512
+#    configuration:
+#        maxmemory_policy: allkeys-ttl
 
 # If you wish to use solr, uncomment this service and the corresponding relationship in .platform.app.yaml.
 # Also, you need to generate the config using:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,9 +25,9 @@ doctrine:
                 user: '%database_user%'
                 password: '%database_password%'
                 charset: '%database_charset%'
-        # Needs to be set to avoid Doctrine opening connection to database to get version info during situation where
-        # database is not ready yet. See: https://symfony.com/doc/current/reference/configuration/doctrine.html
-        server_version: '%database_version%'
+                # Needs to be set to avoid Doctrine opening connection to database to get version info during situation where
+                # database is not ready yet. See: https://symfony.com/doc/current/reference/configuration/doctrine.html
+                server_version: '%database_version%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,9 @@ doctrine:
                 user: '%database_user%'
                 password: '%database_password%'
                 charset: '%database_charset%'
+        # Needs to be set to avoid Doctrine opening connection to database to get version info during situation where
+        # database is not ready yet. See: https://symfony.com/doc/current/reference/configuration/doctrine.html
+        server_version: '%database_version%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -16,6 +16,9 @@ parameters:
     database_charset: '%env(DATABASE_CHARSET)%'
     # collation currently has effect on MySQL only
     database_collation: '%env(DATABASE_COLLATION)%'
+    # Needed by Doctrine Bundle / ORM to avoid it opening connection during situations where there is no service yet.
+    # See: https://symfony.com/doc/current/reference/configuration/doctrine.html
+    database_version: '%env(DATABASE_VERSION)%'
 
     # Setting for mail system, used by SwiftMailer
     mailer_host: '%env(MAILER_HOST)%'
@@ -91,6 +94,7 @@ parameters:
     # set here for BC reasons, change them in parameters.yml
     env(DATABASE_CHARSET): utf8mb4
     env(DATABASE_COLLATION): utf8mb4_unicode_520_ci
+    env(DATABASE_VERSION): mariadb-10.2.26
 
     # Compile time handlers
     ## These are defined at compile time, and hence can't be set at runtime using env()

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,3 +17,4 @@ parameters:
     env(DATABASE_PASSWORD):
     env(DATABASE_CHARSET): utf8mb4
     env(DATABASE_COLLATION): utf8mb4_unicode_520_ci
+    env(DATABASE_VERSION): mariadb-10.2.26

--- a/bin/platformsh/pre_start-per_node-clear_cache.sh
+++ b/bin/platformsh/pre_start-per_node-clear_cache.sh
@@ -9,6 +9,6 @@ echo "removing var/cache/${SYMFONY_ENV}/*.* to avoid Symfony container issues on
 rm -Rf var/cache/${SYMFONY_ENV}/*.*
 #date
 echo "clearing application cache"
-bin/console cache:clear
+php bin/console cache:clear
 #date
 echo "done executing pre_start cache clear"

--- a/bin/platformsh/pre_start-per_node-clear_cache.sh
+++ b/bin/platformsh/pre_start-per_node-clear_cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# This script gets run as part of the .platform.app.yaml deploy step
-# On PE Cluster (usually just production) this should be setup by P.sh team as part of pre_start event
+# This script is run as part of the .platform.app.yaml deployment step
+# On PE Cluster (usually just production) this should be setup by platform.sh team as part of pre_start event
 
 set -e
 

--- a/bin/platformsh/pre_start-per_node-clear_cache.sh
+++ b/bin/platformsh/pre_start-per_node-clear_cache.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This script gets run as part of the .platform.app.yaml deploy step
+# On PE Cluster (usually just production) this should be setup by P.sh team as part of pre_start event
+
+set -e
+
+#date
+echo "removing var/cache/${SYMFONY_ENV}/*.* to avoid Symfony container issues on interface changes"
+rm -Rf var/cache/${SYMFONY_ENV}/*.*
+#date
+echo "clearing application cache"
+bin/console cache:clear
+#date
+echo "done executing pre_start cache clear"

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -4,15 +4,15 @@
 This is the simplest approach, but may be less up to date with current development than the other, more manual approach.
 
 ### Using eZ Platform Cloud
-With eZ Platform Cloud subscription, you are able to create an instance of both open source and Enterprise using templates. In the future it also allow you to create an instance of Commerce version.
+With eZ Platform Cloud subscription, you are able to create an instance of both open source and Enterprise using templates. In the future it will also enable you to create an instance of eZ Commerce.
 
 To use eZ Platform Cloud:
-1. Login at [cloud.ezplatform.com](https://cloud.ezplatform.com/)
-2. Click to Add a project, during setup wizard you'll get the choice to pick a flavour of eZ Platform.
+1. Log in to [cloud.ezplatform.com](https://cloud.ezplatform.com/)
+2. Click Add a project, during setup wizard you'll get the choice to pick a flavor of eZ Platform.
 3. Complete the setup wizard, and your eZ Platform site will be created.
 
 ### Using vanilla platform.sh
-Using an platform.sh account, you can create an instance of open source version of eZ Platform from template:
+Using a platform.sh account, you can create an instance of open source version of eZ Platform from template:
 1. Login or create an account at [Platform.sh](https://platform.sh)
 2. Create a Platform.sh project, using the "Create a blank site from a template" option. Select one of the "eZ Platform" stack templates.
 3. Complete the setup wizard, and your eZ Platform site will be created.
@@ -22,13 +22,13 @@ This requires more manual steps, but may be more up to date with current develop
 
 **NB:** Some optional aspects of the installation require you to be project owner on a Platform.sh project. If you create a new project now, you will be.
 
-1. Login or create an account at [Platform.sh](https://platform.sh) _(or login to [cloud.ezplatform.com](https://cloud.ezplatform.com/) if you have an subscription)_
+1. Log in or create an account at [Platform.sh](https://platform.sh) _(or login to [cloud.ezplatform.com](https://cloud.ezplatform.com/) if you have an subscription)_
 2. Unless this has already been done for you, create a new project by using the **Import your existing code** option. Follow the setup wizard, but halt at the end, before clicking **Finish**.
 3. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) _(or [eZ Platform Enterprise](https://github.com/ezsystems/ezplatform-ee/)/[eZ Commerce](https://github.com/ezsystems/ezcommerce/) if you have a subscription)_ and clone your fork locally.
 4. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard provides the command to use. Example:
    `git remote add platform my_project@git.eu.platform.sh:my_project.git`
 5. [Optional] Authentication against Github/Bitbucket/Gitlab/updates.ez.no for locale development:
-   If you have private packages from own git repositories or use eZ Platform Enterprise, you can use Composer's
+   If you have private packages from your own git repositories or use eZ Platform Enterprise, you can use Composer's
    [auth.json](https://getcomposer.org/doc/articles/http-basic-authentication.md) file or [COMPOSER_AUTH](https://getcomposer.org/doc/03-cli.md#composer-auth) environment variable for this.
    Here's an example of `COMPOSER_AUTH` usage to authenticate for eZ Enterprise packages:
    `export COMPOSER_AUTH='{"http-basic":{"updates.ez.no":{"username":"network-id","password":"token-key"}}}'`
@@ -61,7 +61,7 @@ The bundled config is a recommended safe default that you can start from, just m
 If you are on a Platform.sh Enterprise Dedicated Cluster setup, typically named PE-6 / PE-12 / (...), you'll need to do some adjustment on the platform.sh config and you'll
 have dedicated on-boarding where topics around using eZ Platform on this cluster will be gone true before you can deploy to it.
 
-If you want to read up a bit, look in the bundled platform.sh config. There are a lot of config commented out by default, some of these are explicitly for Dedicated Cluster setup.
+If you want to read up a bit, look in the bundled platform.sh config. There is a lot of config commented out by default, some of these are explicitly for Dedicated Cluster setup.
 
 It's recommended to:
 - Get platform.sh Support to setup `var/cache` and `var/log` as locale mounts to avoid performance issues _(default on PE Cluster is shared)_

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -1,48 +1,92 @@
 # Install eZ Platform on Platform.sh
 
-> **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
-
 ## Installation using eZ Platform template
 This is the simplest approach, but may be less up to date with current development than the other, more manual approach.
 
-1. Login or create an account at [Platform.sh](https://platform.sh)
-1. Create a Platform.sh project, using the "Create a blank site from a template" option. Select the "eZ Platform" stack template.
-1. Complete the setup wizard, and your eZ Platform site will be created.
+### Using eZ Platform Cloud
+With eZ Platform Cloud subscription, you are able to create an instance of both open source and Enterprise using templates. In the future it also allow you to create an instance of Commerce version.
 
-## Installation using an eZ Platform clone
+To use eZ Platform Cloud:
+1. Login at [cloud.ezplatform.com](https://cloud.ezplatform.com/)
+2. Click to Add a project, during setup wizard you'll get the choice to pick a flavour of eZ Platform.
+3. Complete the setup wizard, and your eZ Platform site will be created.
+
+### Using vanilla platform.sh
+Using an platform.sh account, you can create an instance of open source version of eZ Platform from template:
+1. Login or create an account at [Platform.sh](https://platform.sh)
+2. Create a Platform.sh project, using the "Create a blank site from a template" option. Select one of the "eZ Platform" stack templates.
+3. Complete the setup wizard, and your eZ Platform site will be created.
+
+## Manual installation using an eZ Platform Git clone
 This requires more manual steps, but may be more up to date with current development than the template-based approach.
 
 **NB:** Some optional aspects of the installation require you to be project owner on a Platform.sh project. If you create a new project now, you will be.
 
-1. Login or create an account at [Platform.sh](https://platform.sh)
-1. Create a Platform.sh project, using the "Import your existing code" option. Follow the setup wizard, but halt at the end, before clicking "Finish".
-1. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) and clone your fork locally.
-1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
-   `git remote add platform my_project@git.eu.platform.sh:my_project.git`  
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
-      `export SYMFONY_ENV=dev`  
-      If you don't do this, the local build will default to 'prod'.  
-      **NB:** For this to affect remote builds, it must also be set as a Platform.sh project variable, see below.
-1. Push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
+1. Login or create an account at [Platform.sh](https://platform.sh) _(or login to [cloud.ezplatform.com](https://cloud.ezplatform.com/) if you have an subscription)_
+2. Unless this has already been done for you, create a new project by using the **Import your existing code** option. Follow the setup wizard, but halt at the end, before clicking **Finish**.
+3. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) _(or [eZ Platform Enterprise](https://github.com/ezsystems/ezplatform-ee/)/[eZ Commerce](https://github.com/ezsystems/ezcommerce/) if you have a subscription)_ and clone your fork locally.
+4. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard provides the command to use. Example:
+   `git remote add platform my_project@git.eu.platform.sh:my_project.git`
+5. [Optional] Authentication against Github/Bitbucket/Gitlab/updates.ez.no for locale development:
+   If you have private packages from own git repositories or use eZ Platform Enterprise, you can use Composer's
+   [auth.json](https://getcomposer.org/doc/articles/http-basic-authentication.md) file or [COMPOSER_AUTH](https://getcomposer.org/doc/03-cli.md#composer-auth) environment variable for this.
+   Here's an example of `COMPOSER_AUTH` usage to authenticate for eZ Enterprise packages:
+   `export COMPOSER_AUTH='{"http-basic":{"updates.ez.no":{"username":"network-id","password":"token-key"}}}'`
+
+   Further reading also on [docs.platform.sh](https://docs.platform.sh/tutorials/composer-auth.html#set-the-envcomposerauth-project-variable)
+6. [Optional] Set the `env:symfony_env` or `env:COMPOSER_AUTH` project variables by performing the following steps:
+   1. Install the Platform.sh CLI according to https://docs.platform.sh/gettingstarted/own-code/cli-install.html
+   2. Run `platform`
+      Run `platform get <your project id>`
+   3. Authentication against Github/Bitbucket/Gitlab/updates.ez.no
+       For example set the project variables for your eZ Network installation ID and token:
+      `platform project:variable:create env:COMPOSER_AUTH '{"http-basic":{"updates.ez.no":{"username":"network-id","password":"token-key"}}}' --no-visible-runtime --sensitive true`
+   4. If you have the need to debug things remotely, set the `SYMFONY_ENV` environment variable to 'dev':
+      `platform project:variable:set env:SYMONY_ENV dev`.
+7. Push your branch. The Platform.sh setup wizard provides the command to use. Example:
    `git push -u platform master`  
    This starts the build process. Now, finish the Platform.sh setup wizard.
    1. The build may fail due to mismatching SSH keys. If you are project administrator, verify that your Platform.sh project "Deploy key" (under "Configure project") is included among your GitHub SSH keys: https://github.com/settings/keys If not, copy the deploy key and add it on GitHub using the "New SSH key" button. Then push an empty commit to trigger a Platform.sh rebuild:  
       `git commit --allow-empty -m'rebuild' && git push`
-1. Optional: Install the Platform.sh CLI and set the env:symfony_env project variable
-   1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
-   1. Run `platform`  
-      Run `platform get <your project id>`
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
-      `platform project:variable:set env:symfony_env prod`  
-      If you don't do this, remote builds will default to 'prod'.  
-      Then push an empty commit to trigger a Platform.sh rebuild:  
-      `git commit --allow-empty -m'rebuild' && git push`  
-      This will take a while, as it runs the full composer install.
 
-> **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.
->
-> The symptom for this is when, in the backend, you go to Content -> Form Manager and get an error message, or when the "My Drafts Scheduled for Future Publication" and "All Drafts Scheduled for Future Publication" sections on "My Dashboard" will not load.
->
-> To do this, go to the Platform.sh web interface -> "Access site" and copy the "SSH access" command. Then, run the SSH command from a terminal, and:
-> `rm web/var/.platform.installed`
-> The next time you trigger a rebuild (see above), the full install will run.
+# FAQ
+
+## Can I adjust the platform.sh config?
+
+Yes, like all configuration (YML/VCL/..) bundled with the eZ Platform installation, all config in the "root project" is yours, and for you to customize for your needs.
+The bundled config is a recommended safe default that you can start from, just make sure to make it possible to merge in future config changes when you later need to upgrade.
+
+## Using Enterprise Dedicated Cluster
+
+If you are on a Platform.sh Enterprise Dedicated Cluster setup, typically named PE-6 / PE-12 / (...), you'll need to do some adjustment on the platform.sh config and you'll
+have dedicated on-boarding where topics around using eZ Platform on this cluster will be gone true before you can deploy to it.
+
+If you want to read up a bit, look in the bundled platform.sh config. There are a lot of config commented out by default, some of these are explicitly for Dedicated Cluster setup.
+
+It's recommended to:
+- Get platform.sh Support to setup `var/cache` and `var/log` as locale mounts to avoid performance issues _(default on PE Cluster is shared)_
+- Either:
+   A. Enable eZ Clustered DFS setup _(A **requirement** if you use eZ Publish legacy and legacy bridge, due to shared cache files)_.
+   B. Stay with a shared mount on `web/var` for storage files _(images, videos, files)_.
+- Setup own persisted redis service for sessions, to avoid sessions risking being evicted with cache.
+
+Tips:
+- _As always, with help from Platform.sh Support tune memory/disk size for services (Redis, Solr, ..) to make sure it can handle your traffic and data needs._
+- _For use with Redis and Solr we recommend at a minimum a PE-6+ ("ME-6") instance with additional memory available._
+
+## Downgrading services
+
+Note that if you downgrade certain services like mysql, this can cause your deploy to hang. Contact platform.sh support if this happens and they will downgrade it for you.
+
+## Re-install Demo
+
+If you use default config, where database is installed on first deploy and thus have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the `web/var/.platform.installed` file to ensure the installation is performed in the deploy stage.
+
+The symptom for this is when, in the Back Office, you go to **Content** -> **Form** Manager and get an error message or when the "My Drafts Scheduled for Future Publication" and "All Drafts Scheduled for Future Publication" sections on "My Dashboard" do not load.
+
+To do this, you'll need to remove `web/var/.platform.installed`, either using SSH or using `platform` command:
+```
+platform ssh -e [env] 'rm web/var/.platform.installed'
+```
+
+The next time you trigger a rebuild _(can be done in UI)_, the full install will run.

--- a/doc/platformsh/README.md
+++ b/doc/platformsh/README.md
@@ -1,19 +1,16 @@
 # Use eZ Platform on Platform.sh
 
-> **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
-
 ## What is Platform.sh?
 *Platform.sh* is a continuous deployment cloud hosting solution which can replicate a live production setup in seconds and create byte-level clones of throwaway dev and staging environments, which makes human testing and validation easy.
-
-## Current limitations
-- Clustering is not yet tested or supported.
-- Performance is limited, as installation instructions do not yet cover any particular CDN or HTTP caching tools like Varnish or Fastly.
 
 ## Install
 For installation instructions, see [INSTALL.md](https://github.com/ezsystems/ezplatform/blob/master/doc/platformsh/INSTALL.md).
 
 ## Platform.sh configuration files
-You may need to tweak these files after completing the installation.
+You need to tweak these files before pushing to platform.sh setup:
 - [.platform.app.yaml](https://docs.platform.sh/configuration/app-containers.html) controls your application, including dependencies, build and deployment.
 - The `.platform` directory contains Platform.sh service and route settings.
 - `app/config/env/platformsh.php` ensures that database, cache, and sessions provided by or configured for Platform.sh is applied in eZ Platform. You should normally not need to change this, but there may be special cases where it is required.
+
+There are inline comments in these files for choices you should consider, and as stated in [INSTALL.md](https://github.com/ezsystems/ezplatform/blob/master/doc/platformsh/INSTALL.md)
+FAQ there are also specific hints if you plan to use Platform.sh Enterprise Dedicated Cluster setup.


### PR DESCRIPTION
Goals, most trying to improve DX:
- Define clear hints on what should be done on Platform.sh Enterprise Dedicated Cluster, for partner and for Platform.sh staff as well
- Update config to cover more common needs inline
    - _e.g. redis cache clear (NB: varnish/fastly to be covered later as followup)_
- Simplify:  use COMPOSER_AUTH  and ~change to composer flavour~ _(Skipped for now as we need to install another version of node.js in build step)_
- Simplify: Align Enterprise and Open Source doc to cover all in Open source doc to avoid EE doc getting out of sync, possible now thanks to change to suggest generic COMPOSER_AUTH use for any auth needs

Target 2.5LTS and up for simplicity, we could consider bringing this to 1.13LTS as well if we anticipate further changes there (and hence conflicts due to these changes).


*Review guidelines*:
- Please use Github "*Suggest" feature if think something should be different 
- Beware the doc/platformsh/* was written long ago by someone else, and has mostly not been maintained, so I'm trying to brush it up and simplify it a bit. Ideally it should be greatly simplified, and better synced with https://docs.platform.sh/frameworks/ez.html#ez-platform and https://doc.ez.no. _But that is more for someone in eZ + platform.sh product team to deal with and not within the "improvement" scope I'm aiming for here (IMO)_