### PR TITLE
[Travis] Increased default Composer memory limit

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ COMPOSE_DIR=.
 
 # You'll need to adjust this for Windows and XDB Linux systems: https://getcomposer.org/doc/03-cli.md#composer-home
 COMPOSER_HOME=~/.composer
-COMPOSER_MEMORY_LIMIT=2G
+COMPOSER_MEMORY_LIMIT=4G
 DATABASE_USER=ezp
 DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp


### PR DESCRIPTION
Some Travis builds are failing because of Composer memory issues, see:

https://travis-ci.com/ezsystems/ezplatform-page-fieldtype/jobs/226435569
```
install_dependencies_1  | Loading composer repositories with package information
Updating dependencies (including require-dev)
install_dependencies_1  | PHP Fatal error:  Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/Solver.php on line 223
install_dependencies_1  | Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/Solver.php on line 223
install_dependencies_1  | Check https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors for more info on how to handle out of memory errors.Do not run Composer as root/super user! See https://getcomposer.org/root for details

install_dependencies_1  | Loading composer repositories with package information

Updating dependencies (including require-dev)

install_dependencies_1  | PHP Fatal error:  Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52
```

We're already using 4G in some repos (https://github.com/ezsystems/ezplatform-page-builder/blob/1.3/.travis.yml#L15), this allows us to set it for all repos so that the issue is gone.