### PR TITLE
[Composer] Increased BehatBundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "behat/symfony2-extension": "^2.1.5",
         "bex/behat-screenshot": "^1.2.7",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0@dev",
-        "ezsystems/behatbundle": "^6.5.4@dev",
+        "ezsystems/behatbundle": "^7.0.0@dev",
         "overblog/graphiql-bundle": "^0.1.2",
         "phpunit/phpunit": "^6.5.13",
         "sensio/generator-bundle": "^3.1.7",


### PR DESCRIPTION
Increasing version of BehatBundle to 7.0, which has been introduced because of https://github.com/ezsystems/BehatBundle/pull/92#pullrequestreview-277660297

The code in this version is 100% compatible with BehatBundle 6.5.4, but it drops support for older kernel versions. 
People using eZ Platform 2.5 should be able to update to BehatBundle 7.0 without any issues.

BehatBundle 6.5 - can be used with all versions until eZ Platform 3.0 is released
BehatBundle 7.0 - can used with eZ Platform ^2.5, contains new features, but keeps old code
BehatBundle 8.0 (current master) - can used with eZ Platform ^3.0, new features, does not contain old code

Note to self: this has to be changed to ^8.0.0@dev when merging upstream