### PR TITLE
EZP-30714: Fixed default Webpack Encore configuration

### DIFF
--- a/config/packages/ezplatform_assets.yaml
+++ b/config/packages/ezplatform_assets.yaml
@@ -1,5 +1,4 @@
 webpack_encore:
-    output_path: "%kernel.project_dir%/public/assets/build"
     builds:
         ezplatform: "%kernel.project_dir%/public/assets/ezplatform/build"
 

--- a/config/packages/webpack_encore.yaml
+++ b/config/packages/webpack_encore.yaml
@@ -1,7 +1,7 @@
 webpack_encore:
     # The path where Encore is building the assets.
     # This should match Encore.setOutputPath() in webpack.config.js.
-    output_path: '%kernel.project_dir%/public/build'
+    output_path: '%kernel.project_dir%/public/assets/build'
     # If multiple builds are defined (as shown below), you can disable the default build:
     # output_path: false
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30714](https://jira.ez.no/browse/EZP-30714)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (3.0@dev)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently adding project-level Encore configuration (as a default build) results in HTTP 500 error when trying to use `encore_entry_*_tags` Twig functions.

This PR:
- [x] Removes `output_path` from `ezplatform_assets.yaml` extension config to avoid overriding issue.
- [x] Aligns default Encore `output_path` with the one set in the `webpack.config.js`.

## QA
- [x] Sanity check for AdminUI.
- [x] Custom project-level Encore scripts: d1150c09c949f4ad14dd90da18925b94fddf0bf9 (w/o the fix results in the mentioned HTTP 500, with the fix displays `"app"` in a browser console).