### PR TITLE
EZP-30716: Prevent accepting app.php in URL in Platform.sh

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -67,6 +67,14 @@ if ($useHttpCache) {
 
 $request = Request::createFromGlobals();
 
+// Deny request if it contains the frontcontroller script ie. http://example.com/app.php
+$frontControllerScript = preg_quote(basename($request->server->get('SCRIPT_FILENAME')));
+if (preg_match("<^/([^/]+/)?$frontControllerScript([/?#]|$)>", $request->getRequestUri(), $matches) === 1) {
+    http_response_code(400);
+    echo('<html><head><title>400 Bad Request</title></head><body><h1>400 Bad Request</h1></center></body></html>');
+    die;
+}
+
 // If you are behind one or more trusted reverse proxies, you might want to set them in SYMFONY_TRUSTED_PROXIES environment
 // variable in order to get correct client IP
 if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {


### PR DESCRIPTION
Target: 1.7, 1.13, 2.5, master. It has passed QA.

Prevent direct use of app.php in URLs, needed for pSH. It's not possible to do this in `.platform.app.yaml` according to pSH support, so we do it in app.php itself.

The regexp blocks `/folder/app.php` and `/app.php` (for uri-based siteaccess), but allows `/folder/folder/app.php` (two or more levels). It also blocks `/app.php/foo` and `/app.php?foo` and `/app.php#foo`, but allows `/app.php-foo`, `/app.php.foo`, etc.