### PR TITLE
EZP-30906: Removed deprecated templating component integration

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -94,8 +94,6 @@ framework:
         #       default session name will be set to "eZSESSID{siteaccess_hash}" (unique session name per siteaccess)
         #       Further reading on sessions: http://doc.ezplatform.com/en/latest/guide/sessions/
     http_method_override: true
-    templating:
-        engines: [twig]
     cache:
         pools:
             cache.array:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30906](https://jira.ez.no/browse/EZP-30906)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | yes
| **Tests pass**     | [yes](https://travis-ci.org/ezsystems/ezplatform/builds/581547772)
| **Doc needed**     | yes


>List of all related PRs:
https://github.com/ezsystems/ezplatform-design-engine/pull/23
https://github.com/ezsystems/ezplatform-http-cache/pull/100
https://github.com/ezsystems/ezplatform-richtext/pull/66
https://github.com/ezsystems/ezplatform-user/pull/47
https://github.com/ezsystems/ezpublish-kernel/pull/2759
https://github.com/ezsystems/repository-forms/pull/314

>EE:
https://github.com/ezsystems/date-based-publisher/pull/132
https://github.com/ezsystems/flex-workflow/pull/138
https://github.com/ezsystems/ezplatform-form-builder/pull/183
https://github.com/ezsystems/ezplatform-page-builder/pull/390
https://github.com/ezsystems/ezplatform-page-fieldtype/pull/112

Green build:
https://travis-ci.org/ezsystems/ezplatform/builds/581547772

**TODO**:
- [x] Setup Travis