### PR TITLE
Docker on 3.x

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,9 @@ COMPOSE_DIR=.
 COMPOSER_HOME=~/.composer
 COMPOSER_MEMORY_LIMIT=4G
 
+# Feel free to change project name to something meaningful (preferably unique per project)
+COMPOSE_PROJECT_NAME=ezplatform
+
 ## Docker images (name and version)
 PHP_IMAGE=ezsystems/php:7.3-v1
 PHP_IMAGE_DEV=ezsystems/php:7.3-v1-dev

--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -16,4 +16,6 @@ services:
      - DATABASE_PASSWORD
      - DATABASE_NAME
      - COMPOSER_AUTH
+     - DATABASE_PLATFORM
+     - DATABASE_PORT
     command: ./doc/docker/install_script.sh

--- a/doc/docker/install_script.sh
+++ b/doc/docker/install_script.sh
@@ -12,7 +12,6 @@ if [ "$s" != "0" ]; then
 fi
 mkdir -p public/var
 
-
 if [ "${INSTALL_DATABASE}" == "1" ]; then 
     export DATABASE_URL=${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
 

--- a/doc/docker/install_script.sh
+++ b/doc/docker/install_script.sh
@@ -12,7 +12,10 @@ if [ "$s" != "0" ]; then
 fi
 mkdir -p public/var
 
+
 if [ "${INSTALL_DATABASE}" == "1" ]; then 
+    export DATABASE_URL=${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+
     php /scripts/wait_for_db.php
     composer ezplatform-install
     if [ "$APP_CMD" != '' ]; then


### PR DESCRIPTION
According to this [doc](https://symfony.com/doc/current/configuration.html#configuration-based-on-environment-variables) : `The existing env vars are never overwritten by the values defined in .env, so you can combine both.` That seems to be only partially true..

So in .env we have :

```
DATABASE_URL=${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
```

Variables like `DATABASE_NAME` and `DATABASE_PORT` are also set in the `.env` file..
However, it does not work to then change `DATABASE_NAME` via environment variable. It must be changed in `.env` too, because `DATABASE_URL` is defined there. Or, as I do here, redefine `DATABASE_URL` instead

~note : https://github.com/ezsystems/ezplatform/pull/464 should be merged first, and I'll rebase this PR...´~