### PR TITLE
Added graphql schema generation after database install

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -94,4 +94,8 @@ docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 echo '> Install data'
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; composer ezplatform-install"
 
+echo '> Generate GraphQL schema'
+docker-compose exec --user www-data app sh -c "php bin/console ezplatform:graphql:generate-schema"
+docker-compose exec --user www-data app sh -c "php bin/console cache:clear"
+
 echo '> Done, ready to run tests'


### PR DESCRIPTION
After https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/200 GraphQl is always used in the product and the schema must be generated before AdminUI can be used.