### PR TITLE
[Platform.sh] Change to fix execution bit issues with cache script

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -140,7 +140,7 @@ hooks:
 
         # Now that mounts are available, clear cache on mount.
         # Note: Skip on PE Cluster setup using e.g. "if [$PLATFORM_BRANCH" != 'production']; then" & get p.sh to enable this on internal per node "pre_start" hook
-        ./bin/platformsh/pre_start-per_node-clear_cache.sh
+        sh bin/platformsh/pre_start-per_node-clear_cache.sh
 
         # If you also need to clear Redis cache on every deploy, you can either use this command or redis-cli
         # Normally this should only be needed if cached data structures changes (upgrades), or you change data via sql (e.g. restore backup)

--- a/bin/platformsh/pre_start-per_node-clear_cache.sh
+++ b/bin/platformsh/pre_start-per_node-clear_cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # This script is run as part of the .platform.app.yaml deployment step
 # On PE Cluster (usually just production) this should be setup by platform.sh team as part of pre_start event
 


### PR DESCRIPTION
Fixes:
`W: /bin/dash: 16: ./bin/platformsh/pre_start-per_node-clear_cache.sh: Permission denied`


Fixes a few issues:
- Missing execution flag
- Make sure deploy won't fail if execution flag is missing
    - _Issue with updates.ez.no packages due to [ongoing Satis/Composer issue](https://github.com/composer/composer/pull/8331)_
- Swap script to only need shell instead of bash