### PR TITLE
[docker] Increase composer timeout limit on install assets

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,7 @@ COMPOSE_DIR=.
 # You'll need to adjust this for Windows and XDB Linux systems: https://getcomposer.org/doc/03-cli.md#composer-home
 COMPOSER_HOME=~/.composer
 COMPOSER_MEMORY_LIMIT=4G
+COMPOSER_PROCESS_TIMEOUT=600
 
 # Feel free to change project name to something meaningful (preferably unique per project)
 COMPOSE_PROJECT_NAME=ezplatform

--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -9,6 +9,7 @@ services:
      - ${COMPOSER_HOME}:/root/.composer:cached
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - COMPOSER_PROCESS_TIMEOUT
      - APP_ENV=${APP_ENV-prod}
      - APP_DEBUG
      - APP_CMD


### PR DESCRIPTION
Installing assets always fails for me as composer hits it's time limit.

Adding `COMPOSER_PROCESS_TIMEOUT` solves this issue