### PR TITLE
[Docker] Allowed to set PHP memory limit through env

### DIFF
--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -11,6 +11,7 @@ services:
      - db
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-dev}
      - SYMFONY_DEBUG
      - SYMFONY_HTTP_CACHE

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -12,6 +12,7 @@ services:
      - db
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG
      - SYMFONY_HTTP_CACHE


### PR DESCRIPTION
Required by https://github.com/ezsystems/ezplatform-page-builder/pull/406 to fix repository-forms on EE demo tests, which are failing because of memory issues.