### PR TITLE
EZP-31132: [Composer] Explicitly required monolog/monolog:^1.25.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "friendsofsymfony/jsrouting-bundle": "^1.6.3",
         "incenteev/composer-parameter-handler": "^2.1.3",
         "knplabs/knp-menu-bundle": "^2.2.1",
+        "monolog/monolog": "^1.25.2",
         "overblog/graphql-bundle": "^0.11.11",
         "scssphp/scssphp": "~1.0",
         "sensio/distribution-bundle": "^5.0.23",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31132](https://jira.ez.no/browse/EZP-31132)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.5.x` and up.
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

This requirement is needed to avoid installing monolog 2, which indirectly requires Symfony 5 (via `symfony/monolog-bundle`).

The issue was reported as symfony/monolog-bundle#330, however we needed to unblock right now CI failing all over the place.

**TODO**:
- [ ] Wait for Travis to confirm.