### PR TITLE
EZP-31189: Reduce memory required for 1.7 and 1.13 branches to install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,29 +18,29 @@
     },
     "require": {
         "php": "~5.6|~7.0",
-        "doctrine/doctrine-bundle": "^1.9.1",
+        "doctrine/doctrine-bundle": "^1.10.3",
         "egulias/listeners-debug-command-bundle": "^1.9.1",
         "ezsystems/content-on-the-fly-prototype": "~0.1.12@dev",
         "ezsystems/ez-support-tools": "~0.2.1@dev",
-        "ezsystems/ezplatform-solr-search-engine": "^1.5.4@dev",
-        "ezsystems/ezpublish-kernel": "~6.7.7@dev",
-        "ezsystems/platform-ui-bundle": "~1.7.8@dev",
-        "ezsystems/repository-forms": "~1.5.5@dev",
-        "hautelook/templated-uri-bundle": "^1.0 | ^2.1",
+        "ezsystems/ezplatform-solr-search-engine": "^1.5.8@dev",
+        "ezsystems/ezpublish-kernel": "~6.7.10@dev",
+        "ezsystems/platform-ui-bundle": "~1.7.9@dev",
+        "ezsystems/repository-forms": "~1.5.6@dev",
+        "hautelook/templated-uri-bundle": "^1.0 | ^2.1.0",
         "incenteev/composer-parameter-handler": "^2.1.3",
-        "sensio/distribution-bundle": "^3.0.36 | ^4.0.40 | ^5.0.22",
+        "sensio/distribution-bundle": "^3.0.36 | ^4.0.42 | ^5.0.25",
         "sensio/framework-extra-bundle": "^3.0.29",
         "sensio/generator-bundle": "^2.5.3",
-        "sensiolabs/security-checker": "^5.0",
+        "sensiolabs/security-checker": "^5.0.3",
         "symfony/assetic-bundle": "~2.8.2",
         "symfony/expression-language": "^2.8.47",
         "symfony/monolog-bundle": "^2.12.1",
         "symfony/swiftmailer-bundle": "^2.6.7",
-        "symfony/symfony": "~2.8.47",
+        "symfony/symfony": "~2.8.52",
         "tedivm/stash-bundle": "^0.6.2",
-        "twig/extensions": "^1.5.3",
+        "twig/extensions": "^1.5.4",
         "white-october/pagerfanta-bundle": "~1.0.8",
-        "willdurand/js-translation-bundle": "^2.6"
+        "willdurand/js-translation-bundle": "^2.6.6"
     },
     "require-dev": {
         "behat/behat": "^3.5.0",
@@ -48,9 +48,9 @@
         "behat/mink-goutte-driver": "^1.2.1",
         "behat/mink-selenium2-driver": "^1.3.1",
         "behat/symfony2-extension": "^2.1.5",
-        "bex/behat-screenshot": "^1.2.7",
-        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.0.0",
-        "ezsystems/behatbundle": "^6.5.4"
+        "bex/behat-screenshot": "^1.2.8",
+        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.1",
+        "ezsystems/behatbundle": "^6.5.8"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31189

Trying to unblock failing (https://travis-ci.org/ezsystems/ezplatform/builds/617477582) Travis tests by limiting memory required by Composer.

Merging: If this is approved I will prepare a PR to 1.13 with suggested changes and send it to review - if approved I will close that PR and apply the changes when merging.
These changes should not be applied for 2.5 and master.