### PR TITLE
EZEE-2928: [Behat] Changed debug value to true for Symfony2Extention

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -26,7 +26,7 @@ default:
                 path: app/AppKernel.php
                 class: AppKernel
                 env: behat
-                debug: false
+                debug: true
 
         EzSystems\PlatformBehatBundle\ServiceContainer\EzBehatExtension: ~
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZEE-2928

**TO DO:** Remove TMP commit before merge

In most (if not all) jobs we're running tests with SYMFONY_DEBUG (or APP_DEBUG) set to true:
https://github.com/ezsystems/ezplatform/blob/2.5/.travis.yml#L13
https://github.com/ezsystems/ezplatform/blob/master/.travis.yml#L13
https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/.travis.yml#L10
https://github.com/ezsystems/ezplatform-admin-ui/blob/master/.travis.yml#L10
https://github.com/ezsystems/ezplatform-page-builder/blob/1.3/.travis.yml#L13
https://github.com/ezsystems/ezplatform-page-builder/blob/master/.travis.yml#L13
https://github.com/ezsystems/ezplatform-form-builder/blob/1.2/.travis.yml#L10
https://github.com/ezsystems/ezplatform-form-builder/blob/master/.travis.yml#L10
https://github.com/ezsystems/ezpublish-kernel/blob/master/.travis.yml#L35
https://github.com/ezsystems/ezpublish-kernel/blob/7.5/.travis.yml#L30
(...)

Yet we are setting incorrect value of debug in Behat's Symfony container. Turns out it the cache is cleared correctly when performing actions using the API, but not when the YAML config is updated, examples:
1) Adding Workflow in https://travis-ci.com/ezsystems/ezplatform-workflow/jobs/261620453#L905 - even though the Workflow is added and the clear cache command is issued the cache is not properly cleared, as it's not found using the API

2) Only in this PR the BehatBundle job is failing: https://travis-ci.org/ezsystems/ezplatform/jobs/618606201#L1325 , meaning the cache was not properly cleared before - the failure is a valid one, this setting is not valid for open source edition.

Requires https://github.com/ezsystems/BehatBundle/pull/117 to make tests green.
Required by https://github.com/ezsystems/ezplatform-workflow/pull/97

