### PR TITLE
[Travis] Increased Composer memory limit for install

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ COMPOSE_DIR=.
 
 # You'll need to adjust this for Windows and XDB Linux systems: https://getcomposer.org/doc/03-cli.md#composer-home
 COMPOSER_HOME=~/.composer
-COMPOSER_MEMORY_LIMIT=2G
+COMPOSER_MEMORY_LIMIT=3G
 DATABASE_USER=ezp
 DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp


### PR DESCRIPTION
Looks like the solution from https://github.com/ezsystems/ezplatform/pull/482 was working a week ago, but in the meantime Composer starting demanding even more memory 😞 See https://travis-ci.org/ezsystems/ezplatform/builds/620130994?utm_source=slack&utm_medium=notification

Increasing the memory limit should do the trick.