### PR TITLE
[Composer] Added doctrine/persistence conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
     "conflict": {
         "symfony/symfony": "3.4.9||3.4.12||3.4.16",
         "doctrine/dbal": "2.7.0",
+        "doctrine/persistence": "1.3.2",
         "twig/twig": "2.6.1",
         "symfony/webpack-encore-bundle": "1.2.0||1.2.1"
     },


### PR DESCRIPTION
Adding conflict of doctrine/persistance because our product fails to install with:
```
Script eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::clearCache handling the symfony-scripts event terminated with an exception


  [RuntimeException]
  An error occurred when executing the "'cache:clear --no-warmup'" command:


  Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Doctrine\ORM\Configuration::s
  etMetadataDriverImpl() must be an instance of Doctrine\Common\Persistence\Mapping\Driver\MappingDriver, instance of Doctrine\Persistence\Ma
  pping\Driver\MappingDriverChain given, called in /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9gat/get
  Doctrine_Orm_DefaultEntityManagerService.php on line 25 in /Users/mareknocon/Desktop/repos/test_install/ezplatform/vendor/doctrine/orm/lib/
  Doctrine/ORM/Configuration.php:149
  Stack trace:
  #0 /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9gat/getDoctrine_Orm_DefaultEntityManagerService.php(2
  5): Doctrine\ORM\Configuration->setMetadataDriverImpl(Object(Doctrine\Persistence\Mapping\Driver\MappingDriverChain))
  #1 /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9gat/appDevDebugProjectContainer.php(5501): require('/
  Users/mareknoc...')
  #2 /Users/marekno in /Users/mareknocon/Desktop/repos/test_install/ezplatform/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php on line
   149


  PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Doctrine\ORM\Configurati
  on::setMetadataDriverImpl() must be an instance of Doctrine\Common\Persistence\Mapping\Driver\MappingDriver, instance of Doctrine\Persisten
  ce\Mapping\Driver\MappingDriverChain given, called in /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9ga
  t/getDoctrine_Orm_DefaultEntityManagerService.php on line 25 in /Users/mareknocon/Desktop/repos/test_install/ezplatform/vendor/doctrine/orm
  /lib/Doctrine/ORM/Configuration.php:149
  Stack trace:
  #0 /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9gat/getDoctrine_Orm_DefaultEntityManagerService.php(2
  5): Doctrine\ORM\Configuration->setMetadataDriverImpl(Object(Doctrine\Persistence\Mapping\Driver\MappingDriverChain))
  #1 /Users/mareknocon/Desktop/repos/test_install/ezplatform/var/cache/dev/ContainerP9f9gat/appDevDebugProjectContainer.php(5501): require('/
  Users/mareknoc...')
  #2 /Users/marekno in /Users/mareknocon/Desktop/repos/test_install/ezplatform/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php on line
   149
```

More info:
https://github.com/doctrine/persistence/issues/81

Let's wait for Travis tests, as they have released 3 versions (1.3.0, 1.3.1, 1.3.2) in 15 hours and I'm not sure right now 1.3.1 jest ok, up for Travis to verify