### PR TITLE
Adapt 'platform variable:create' to changed syntax

### DIFF
--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -42,7 +42,7 @@ This requires more manual steps, but may be more up to date with current develop
        For example set the project variables for your eZ Network installation ID and token:
       `platform variable:create --level project --name env:COMPOSER_AUTH --json true --visible-runtime false --value '{"http-basic": {"updates.ez.no": {"username": "network-id", "password": "token"}}}'`
    4. If you have the need to debug things remotely, set the `SYMFONY_ENV` environment variable to 'dev':
-      `platform variable:update --name env:SYMONY_ENV --value 'dev'`.
+      `platform variable:update env:SYMONY_ENV --value 'dev'`.
 7. Push your branch. The Platform.sh setup wizard provides the command to use. Example:
    `git push -u platform master`  
    This starts the build process. Now, finish the Platform.sh setup wizard.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -42,7 +42,7 @@ This requires more manual steps, but may be more up to date with current develop
        For example set the project variables for your eZ Network installation ID and token:
       `platform variable:create --level project --name env:COMPOSER_AUTH --json true --visible-runtime false --value '{"http-basic": {"updates.ez.no": {"username": "network-id", "password": "token"}}}'`
    4. If you have the need to debug things remotely, set the `SYMFONY_ENV` environment variable to 'dev':
-      `platform project:variable:set env:SYMONY_ENV dev`.
+      `platform variable:update --name env:SYMONY_ENV --value 'dev'`.
 7. Push your branch. The Platform.sh setup wizard provides the command to use. Example:
    `git push -u platform master`  
    This starts the build process. Now, finish the Platform.sh setup wizard.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -40,7 +40,7 @@ This requires more manual steps, but may be more up to date with current develop
       Run `platform get <your project id>`
    3. Authentication against Github/Bitbucket/Gitlab/updates.ez.no
        For example set the project variables for your eZ Network installation ID and token:
-      `platform project:variable:create env:COMPOSER_AUTH '{"http-basic":{"updates.ez.no":{"username":"network-id","password":"token-key"}}}' --no-visible-runtime --sensitive true`
+      `platform variable:create --level project --name env:COMPOSER_AUTH --json true --visible-runtime false --value '{"http-basic": {"updates.ez.no": {"username": "network-id", "password": "token"}}}'`
    4. If you have the need to debug things remotely, set the `SYMFONY_ENV` environment variable to 'dev':
       `platform project:variable:set env:SYMONY_ENV dev`.
 7. Push your branch. The Platform.sh setup wizard provides the command to use. Example:


### PR DESCRIPTION
Syntax in platform CLI according to:
https://docs.platform.sh/tutorials/composer-auth.html#set-the-envcomposerauth-project-variable