### PR TITLE
EZP-31313: Make Behat SiteAccess aware

### DIFF
--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -11,6 +11,7 @@ services:
      - db
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - EZPLATFORM_SITEACCESS
      - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-dev}
      - SYMFONY_DEBUG

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -12,6 +12,7 @@ services:
      - db
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - EZPLATFORM_SITEACCESS
      - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31313

Related PRs:
https://github.com/ezsystems/ezpublish-kernel/pull/2933
https://github.com/ezsystems/BehatBundle/pull/124

Passing the env allowing to control SiteAccess used by Behat to Docker containers.

Before merging:
- [x] Remove TMP Travis changes