### PR TITLE
[Travis] Changed user running REST tests to root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ before_script:
 # Execute test command, need to use sh to get right exit code (docker/compose/issues/3379)
 # Behat will use behat.yml which is a copy of behat.yml.dist with hostnames update by doc/docker/selenium.yml
 script:
-  - if [ "${TEST_CMD}" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "$TEST_CMD" ; fi
+  - if [ "${TEST_CMD}" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec app sh -c "$TEST_CMD" ; fi
   - if [ "${BEHAT_OPTS}" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
 
 


### PR DESCRIPTION
Failing build: https://travis-ci.org/ezsystems/ezplatform/builds/646206739
Error:
```
  - Installing ezsystems/doctrine-dbal-schema (dev-master 3573a95): Cloning failed using an ssh key for authentication, enter your GitHub credentials to access private repos
1266
Head to https://github.com/settings/tokens/new?scopes=repo&description=Composer+on+1bc5fc67dd75+2020-02-04+0746
1267
to retrieve a token. It will be stored in “/root/.composer/auth.json” for future use by Composer.
1268
Token (hidden): 
```

When we look at a passing build: https://travis-ci.org/ezsystems/ezplatform/jobs/645236648?utm_source=slack we can see:
```
$ if [ "${TEST_CMD}" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "$TEST_CMD" ; fi

/home/travis/.travis/functions: line 109: cd: /home/travis/build/ezplatform: No such file or directory

Cannot create cache directory /root/.composer/cache/repo/https---repo.packagist.org/, or directory is not writable. Proceeding without cache

Cannot create cache directory /root/.composer/cache/files/, or directory is not writable. Proceeding without cache

Loading composer repositories with package information

Updating dependencies (including require-dev)

Package operations: 131 installs, 0 updates, 0 removals
  - Installing ocramius/package-versions (1.5.1): Downloading (100%)
  - Installing psr/container (1.0.0): Downloading (100%)
  - Installing symfony/service-contracts (v2.0.1): Downloading (100%)
  - Installing psr/cache (1.0.1): Downloading (100%)
(...)
  - Installing ezsystems/doctrine-dbal-schema (dev-master 3573a95): Cloning 3573a95314
  - Installing symfony/doctrine-bridge (v4.4.4): Downloading (100%)
  - Installing jdorn/sql-formatter (v1.2.17): Downloading (100%)
  - Installing doctrine/doctrine-cache-bundle (1.4.0): Downloading (100%)
  - Installing doctrine/doctrine-bundle (1.12.7): Downloading (100%)
  - Installing ezsystems/ezpublish-kernel (dev-master a2dd5ad): Cloning a2dd5ad2af
```

Composer home in Docker `app` container is set to `/root/.composer` (https://github.com/ezsystems/docker-php/blob/master/php/Dockerfile-7.3#L10), which cannot be accessed by www-data user - Composer cache from host is not available to us in this scenario(even though there is a volume that shares it: https://github.com/ezsystems/ezplatform/blob/master/doc/docker/base-dev.yml#L9) 

Idea:
* We're hitting GitHub API limit? The message is misleading, but there is an issue in Composer that would confirm that: https://github.com/composer/composer/issues/1570 (but it's really old).

Running the `composer install` comand as root makes the Composer cache accesible inside the container, which makes the whole install process pass (probably because we're making less requests to GitHub). Logs:
```
  - Installing php-http/promise (v1.0.0): Loading from cache
(...)
  - Installing friendsofsymfony/http-cache (2.9.0): Loading from cache
  - Installing friendsofsymfony/http-cache-bundle (2.8.0): Loading from cache
  - Installing doctrine/dbal (v2.10.1): Loading from cache
  - Installing ezsystems/doctrine-dbal-schema (dev-master 3573a95): Cloning 3573a95314 from cache
  - Installing symfony/doctrine-bridge (v4.4.4): Loading from cache
  - Installing jdorn/sql-formatter (v1.2.17): Loading from cache
  - Installing doctrine/doctrine-cache-bundle (1.4.0): Loading from cache
  - Installing doctrine/doctrine-bundle (1.12.7): Loading from cache
  - Installing ezsystems/ezpublish-kernel (dev-master 8605b24): Cloning 8605b2406e from cache
```

Possible actions:
1) Run the REST tests as root (remove the --user=www-data from all .travis.yml files, for example also here: https://github.com/ezsystems/ezplatform-http-cache/blob/master/.travis.yml#L53) - this fixes the tests for now
2) Make the Composer cache inside `app` container accesible to users other than `root` (requires  moving $COMPOSER_HOME somewhere else and releasing new Docker images probably)