### PR TITLE
EZP-31377: Use imagick by default on Platform.sh to avoid memory issues

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -169,3 +169,7 @@ jms_translation:
             output_dir: '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui-modules/Resources/translations/'
             excluded_dirs: [Behat, Tests, node_modules]
             output_format: "xliff"
+
+liip_imagine:
+    # valid drivers options include "gd" or "gmagick" or "imagick"
+    driver: "%liip_imagine.driver%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -172,4 +172,4 @@ jms_translation:
 
 liip_imagine:
     # valid drivers options include "gd" or "gmagick" or "imagick"
-    driver: "%liip_imagine.driver%"
+    driver: "%liip_imagine_driver%"

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -122,3 +122,6 @@ parameters:
     # Varnish invalidation/purge token (for use on platform.sh, eZ Platform Cloud and other places you can't use IP for ACL)
     varnish_invalidate_token: '%env(HTTPCACHE_VARNISH_INVALIDATE_TOKEN)%'
     env(HTTPCACHE_VARNISH_INVALIDATE_TOKEN): ~
+    
+    # LiipImagineBundle - imagine driver
+    liip_imagine.driver: 'gd'

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -124,4 +124,4 @@ parameters:
     env(HTTPCACHE_VARNISH_INVALIDATE_TOKEN): ~
     
     # LiipImagineBundle - imagine driver
-    liip_imagine.driver: 'gd'
+    liip_imagine_driver: 'gd'

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -163,7 +163,8 @@ if (!getenv('HTTPCACHE_VARNISH_INVALIDATE_TOKEN')) {
     $container->setParameter('varnish_invalidate_token', getenv('PLATFORM_PROJECT_ENTROPY'));
 }
 
-// Detect if imagick is enabled, if so get imagine to use it to reduce memory use (compared to GD which uses PHP memory)
+// Adapt config based on enabled PHP extensions
+// Get imagine to use imagick if enabled, to ravoid using php memory for image convertions
 if (extension_loaded('imagick')) {
-    $container->setParameter('liip_imagine.driver', '');
+    $container->setParameter('liip_imagine.driver', 'imagick');
 }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -164,7 +164,7 @@ if (!getenv('HTTPCACHE_VARNISH_INVALIDATE_TOKEN')) {
 }
 
 // Adapt config based on enabled PHP extensions
-// Get imagine to use imagick if enabled, to ravoid using php memory for image convertions
+// Get imagine to use imagick if enabled, to avoid using php memory for image convertions
 if (extension_loaded('imagick')) {
     $container->setParameter('liip_imagine.driver', 'imagick');
 }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -166,5 +166,5 @@ if (!getenv('HTTPCACHE_VARNISH_INVALIDATE_TOKEN')) {
 // Adapt config based on enabled PHP extensions
 // Get imagine to use imagick if enabled, to avoid using php memory for image convertions
 if (extension_loaded('imagick')) {
-    $container->setParameter('liip_imagine.driver', 'imagick');
+    $container->setParameter('liip_imagine_driver', 'imagick');
 }

--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -162,3 +162,8 @@ if ($route !== null && !getenv('HTTPCACHE_PURGE_TYPE')) {
 if (!getenv('HTTPCACHE_VARNISH_INVALIDATE_TOKEN')) {
     $container->setParameter('varnish_invalidate_token', getenv('PLATFORM_PROJECT_ENTROPY'));
 }
+
+// Detect if imagick is enabled, if so get imagine to use it to reduce memory use (compared to GD which uses PHP memory)
+if (extension_loaded('imagick')) {
+    $container->setParameter('liip_imagine.driver', '');
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31377](https://jira.ez.no/browse/EZP-31377)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.5`
| **BC breaks**      | no
| **Tests pass**     | N/A
| **Doc needed**     | no

GD uses PHP memory and hence it's better if we can use imagick if it's available to avoid risking running into php memory issues on larger images.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
