### PR TITLE
[Platform.sh] Updated Maria DB version to 10.4

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -4,8 +4,7 @@
 #     Reach out to platform.sh support to get help on this and insight into your disk/memory usage.
 
 mysqldb:
-    # Note: You might want to set Doctrine's "server_version" setting to avoid that it tries to connect to database to get version
-    type: mariadb:10.2
+    type: mariadb:10.4
     disk: 1024
     configuration:
         schemas:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "knplabs/knp-menu-bundle": "^2.2",
         "monolog/monolog": "^1.25.2",
         "php-http/guzzle6-adapter": "^2.0",
-        "platformsh/symfonyflex-bridge": "^2.1",
+        "platformsh/symfonyflex-bridge": "^2.2",
         "sensio/framework-extra-bundle": "^5.1",
         "sensiolabs/security-checker": "^5.0",
         "symfony/asset": "^4.3",


### PR DESCRIPTION
Doctrine version handling for Maria DB was fixed in https://github.com/platformsh/symfonyflex-bridge/releases/tag/2.2.0. And it lets to use `10.4` without any errors/issues.