### PR TITLE
EZP-31505: Varnish config is loaded only when varnish set as purge_type

### DIFF
--- a/.env
+++ b/.env
@@ -51,7 +51,7 @@ CACHE_DSN=localhost
 # eZ Platform HTTP Cache
 HTTPCACHE_DEFAULT_TTL=86400
 HTTPCACHE_PURGE_SERVER=http://localhost:80
-HTTPCACHE_VARNISH_INVALIDATE_TOKEN=~
+HTTPCACHE_VARNISH_INVALIDATE_TOKEN=
 
 # Uncomment following line if you want to change the purge type.
 # By default it will use `local` purge when running locally

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ezsystems/ezplatform-cron": "^3.0@dev",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
         "ezsystems/ezplatform-graphql": "^2.0@dev",
-        "ezsystems/ezplatform-http-cache": "^2.0@dev",
+        "ezsystems/ezplatform-http-cache": "dev-load-varnish-only-when-used as ^2.0@dev",
         "ezsystems/ezplatform-kernel": "^1.0@dev",
         "ezsystems/ezplatform-matrix-fieldtype": "^2.0@dev",
         "ezsystems/ezplatform-query-fieldtype": "^2.0@dev",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -19,7 +19,6 @@ return [
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     Bazinga\Bundle\JsTranslationBundle\BazingaJsTranslationBundle::class => ['all' => true],
     Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
-    FOS\HttpCacheBundle\FOSHttpCacheBundle::class => ['all' => true],
     eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle::class => ['all' => true],
     EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle::class => ['all' => true],
     eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle::class => ['all' => true],
@@ -52,4 +51,5 @@ return [
     BabDev\PagerfantaBundle\BabDevPagerfantaBundle::class => ['all' => true],
     FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test' => true, 'behat' => true],
     Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle::class => ['all' => true],
+    FOS\HttpCacheBundle\FOSHttpCacheBundle::class => ['all' => true],
 ];

--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -34,7 +34,7 @@ parameters:
     # env: SESSION_HANDLER_ID
     ezplatform.session.handler_id: session.handler.native_file
 
-    ## Purge type used by HttpCache system ("local", "varnish"/"http", and on ee also "fastly")
+    ## Purge type used by HttpCache system ("local", "varnish", and on ee also "fastly")
     # env: HTTPCACHE_PURGE_TYPE
     purge_type: local
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-31505

main PR:
https://github.com/ezsystems/ezplatform-http-cache/pull/123

as for change in `.env` - using `~` as default variable didn't set symfony parameter to default null but to `~` and that didn't seem very secure. So right now also it must be explicite set to use authorization by token:
https://github.com/ezsystems/ezplatform-http-cache/pull/123/files#diff-006816ea733cc0564d6a5b345ed47929R39