### PR TITLE
EZP-31519: Moved app.php rejection snippet from front controller to ezpublish-kernel

### DIFF
--- a/doc/apache2/vhost.2.2.template
+++ b/doc/apache2/vhost.2.2.template
@@ -94,7 +94,7 @@
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Prevent access to website with direct usage of app.php in URL
-        RewriteRule ^/(.+/)?app\.php - [R=404,L]
+        RewriteRule ^/([^/]+/)?app\.php([/?#]|$) - [R=404,L]
 
         RewriteRule .* /app.php
     </IfModule>

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -105,7 +105,7 @@
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Prevent access to website with direct usage of app.php in URL
-        RewriteRule ^/(.+/)?app\.php - [R=404,L]
+        RewriteRule ^/([^/]+/)?app\.php([/?#]|$) - [R=404,L]
 
         RewriteRule .* /app.php
     </IfModule>

--- a/doc/nginx/ez_params.d/ez_rewrite_params
+++ b/doc/nginx/ez_params.d/ez_rewrite_params
@@ -18,7 +18,7 @@ rewrite "^/bundles/(.*)" "/bundles/$1" break;
 rewrite "^/assets/(.*)" "/assets/$1" break;
 
 # Prevent access to website with direct usage of app.php in URL
-if ($request_uri ~ "^/(.+/)?app\.php") {
+if ($request_uri ~ "^/([^/]+/)?app\.php([/?#]|$)") {
     return 404;
 }
 

--- a/web/app.php
+++ b/web/app.php
@@ -64,14 +64,6 @@ if ($useHttpCache) {
 
 $request = Request::createFromGlobals();
 
-// Deny request if it contains the frontcontroller script ie. http://example.com/app.php
-$frontControllerScript = preg_quote(basename($request->server->get('SCRIPT_FILENAME')));
-if (preg_match("<^/([^/]+/)?$frontControllerScript([/?#]|$)>", $request->getRequestUri(), $matches) === 1) {
-    http_response_code(400);
-    echo('<html><head><title>400 Bad Request</title></head><body><h1>400 Bad Request</h1></center></body></html>');
-    die;
-}
-
 // If you are behind one or more trusted reverse proxies, you might want to set them in SYMFONY_TRUSTED_PROXIES environment
 // variable in order to get correct client IP
 if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31519

I've changed the rule in `vhost.template` files in order to unify logic in both places. This way we can block some requests on httpd level.

Rejection logic has been moved to: https://github.com/ezsystems/ezpublish-kernel/pull/3010