### PR TITLE
Fixed incorrect link to discuss.ezplatform.com

### DIFF
--- a/templates/themes/standard/full/welcome_page.html.twig
+++ b/templates/themes/standard/full/welcome_page.html.twig
@@ -131,7 +131,7 @@
                         <h2 class="mb-3">{{ 'ezplatform_welcome_page.forums_and_community'|trans|desc('Forums and community') }}</h2>
                         <ul class="list-unstyled">
                             <li>
-                                <a href="(https://discuss.ezplatform.com" target="_blank">
+                                <a href="https://discuss.ezplatform.com" target="_blank">
                                     {{ 'ezplatform_welcome_page.discussion_forum'|trans|desc('Discussion forum') }}
                                 </a>
                             </li>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31518

## Description

 https://github.com/ezsystems/ezplatform/pull/515 follow up . Removed "(" from eZ Platform discuss link.