### PR TITLE
Prepared database upgrade scripts for eZ Platform 3.0.0

### DIFF
--- a/upgrade/db/mysql/ezplatform-2.5.latest-to-3.0.0.sql
+++ b/upgrade/db/mysql/ezplatform-2.5.latest-to-3.0.0.sql
@@ -1,0 +1,28 @@
+-- Product name migration
+START TRANSACTION;
+DELETE FROM ezsite_data WHERE name IN ('ezpublish-version', 'ezplatform-release');
+INSERT INTO ezsite_data (name, value) VALUES ('ezplatform-release', '3.0.0');
+COMMIT;
+
+--
+ALTER TABLE ezcontentclass_attribute MODIFY data_text1 VARCHAR(255);
+--
+
+--
+ALTER TABLE ezcontentclass_attribute ADD COLUMN is_thumbnail TINYINT(1) NOT NULL DEFAULT '0';
+--
+
+-- EZP-31471: Keywords versioning
+ALTER TABLE `ezkeyword_attribute_link`
+    ADD COLUMN `version` INT(11) NOT NULL,
+    ADD KEY `ezkeyword_attr_link_oaid_ver` (`objectattribute_id`, `version`);
+
+UPDATE `ezkeyword_attribute_link` SET `version` = (
+    SELECT `current_version`
+    FROM `ezcontentobject_attribute` AS `cattr`
+    JOIN `ezcontentobject` AS `contentobj`
+        ON `cattr`.`contentobject_id` = `contentobj`.`id`
+        AND `cattr`.`version` = `contentobj`.`current_version`
+    WHERE `cattr`.`id` = `ezkeyword_attribute_link`.`objectattribute_id`
+);
+--

--- a/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
+++ b/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
@@ -1,0 +1,30 @@
+-- Product name migration
+START TRANSACTION;
+DELETE FROM ezsite_data WHERE name IN ('ezpublish-version', 'ezplatform-release');
+INSERT INTO ezsite_data (name, value) VALUES ('ezplatform-release', '3.0.0');
+COMMIT;
+
+--
+ALTER TABLE ezcontentclass_attribute ALTER COLUMN data_text1 TYPE varchar(255);
+--
+
+--
+ALTER TABLE ezcontentclass_attribute ADD is_thumbnail boolean DEFAULT false NOT NULL;
+--
+
+-- EZP-31471: Keywords versioning
+ALTER TABLE ezkeyword_attribute_link ADD COLUMN version INT;
+
+UPDATE ezkeyword_attribute_link SET "version" = (
+    SELECT current_version
+    FROM ezcontentobject_attribute AS cattr
+    JOIN ezcontentobject AS contentobj
+        ON cattr.contentobject_id = contentobj.id
+        AND cattr.version = contentobj.current_version
+    WHERE cattr.id = ezkeyword_attribute_link.objectattribute_id
+);
+
+ALTER TABLE ezkeyword_attribute_link ALTER COLUMN version SET NOT NULL;
+
+CREATE INDEX ezkeyword_attr_link_oaid_ver ON ezkeyword_attribute_link (objectattribute_id, version);
+--


### PR DESCRIPTION
Required by: ezsystems/ezplatform-kernel#31

This PR introduces database upgrade scripts to migrate from eZ Platform 2.5 to 3.0.0.

Usually those scripts were placed in `ezpublish-kernel` package, but with package name and versioning change, it might be to confusing. The new way is to place it in here in the meta repository.

Moreover `ezsite_data` will now contain `ezplatform-release` key.