### PR TITLE
Changed APP_TRUSTED_PROXIES variable to TRUSTED_PROXIES

### DIFF
--- a/bin/vhost.sh
+++ b/bin/vhost.sh
@@ -12,7 +12,7 @@ declare -a option_vars=(
     %APP_ENV%
     %APP_DEBUG%
     %APP_HTTP_CACHE%
-    %APP_TRUSTED_PROXIES%
+    %TRUSTED_PROXIES%
     %BODY_SIZE_LIMIT%
     %TIMEOUT%
     %FASTCGI_PASS%

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -56,7 +56,7 @@
     # Optional: Whether to use Symfony's builtin HTTP Caching Proxy.
     # Disable it if you are using an external reverse proxy (e.g. Varnish)
     # Possible values: 0, 1 or ""
-    # Defaults to disabled if APP_ENV is set to "dev" or APP_TRUSTED_PROXIES is set,
+    # Defaults to disabled if APP_ENV is set to "dev" or TRUSTED_PROXIES is set,
     # and if this env value is omitted or empty
     #if[APP_HTTP_CACHE] SetEnv APP_HTTP_CACHE "%APP_HTTP_CACHE%"
 
@@ -64,7 +64,7 @@
     # Needed when using Varnish as proxy, if so disable APP_HTTP_CACHE.
     # Separate entries by a comma, example: "ip1,ip2"
     # Defaults to not be set if env value is omitted or empty
-    #if[APP_TRUSTED_PROXIES] SetEnv APP_TRUSTED_PROXIES "%APP_TRUSTED_PROXIES%"
+    #if[TRUSTED_PROXIES] SetEnv TRUSTED_PROXIES "%TRUSTED_PROXIES%"
 
     # TIP: There are many more environment variables supported by eZ Platform. However unlike those listed above
     #      they should in most cases rather be set in the environment then in vhost config to make sure cronjobs

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -16,7 +16,7 @@ services:
      - APP_ENV=${APP_ENV-dev}
      - APP_DEBUG
      - APP_HTTP_CACHE
-     - APP_TRUSTED_PROXIES
+     - TRUSTED_PROXIES
      - DATABASE_USER
      - DATABASE_PASSWORD
      - DATABASE_NAME

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -17,7 +17,7 @@ services:
      - APP_ENV=${APP_ENV-prod}
      - APP_DEBUG
      - APP_HTTP_CACHE
-     - APP_TRUSTED_PROXIES
+     - TRUSTED_PROXIES
      - DATABASE_USER
      - DATABASE_PASSWORD
      - DATABASE_NAME

--- a/doc/docker/distribution.yml
+++ b/doc/docker/distribution.yml
@@ -23,7 +23,7 @@ services:
      - APP_ENV=${APP_ENV-prod}
      - APP_DEBUG
      - APP_HTTP_CACHE
-     - APP_TRUSTED_PROXIES
+     - TRUSTED_PROXIES
      - DATABASE_USER
      - DATABASE_PASSWORD
      - DATABASE_NAME

--- a/doc/docker/my-ez-app-stack.yml
+++ b/doc/docker/my-ez-app-stack.yml
@@ -25,7 +25,6 @@ services:
      - APP_ENV=prod
      - APP_DEBUG
      - APP_HTTP_CACHE
-     - APP_TRUSTED_PROXIES
      - DATABASE_USER=ezp
      - DATABASE_PASSWORD=SetYourOwnPassword
      - DATABASE_NAME=ezp
@@ -33,7 +32,7 @@ services:
      - CUSTOM_CACHE_POOL=singleredis
      - CACHE_HOST=redis
      - APP_HTTP_CACHE=0
-     - APP_TRUSTED_PROXIES=varnish
+     - TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
      - HTTPCACHE_PURGE_TYPE=http
      - PHP_INI_ENV_session.save_handler=redis

--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -9,7 +9,7 @@ services:
   app:
     environment:
      - APP_HTTP_CACHE=0
-     - APP_TRUSTED_PROXIES=varnish
+     - TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
      - HTTPCACHE_PURGE_TYPE=varnish
 

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -58,7 +58,7 @@ server {
             # Needed when using Varnish as proxy, if so disable APP_HTTP_CACHE.
             # Separate entries by a comma, example: "ip1,ip2"
             # Defaults to not be set if env value is omitted or empty
-            #if[APP_TRUSTED_PROXIES] fastcgi_param APP_TRUSTED_PROXIES "%APP_TRUSTED_PROXIES%";
+            #if[TRUSTED_PROXIES] fastcgi_param TRUSTED_PROXIES "%TRUSTED_PROXIES%";
 
             # TIP: There are many more environment variables supported by eZ Platform. However unlike those listed above
             #      they should in most cases rather be set in the environment then in vhost config to make sure cronjobs


### PR DESCRIPTION
The environment variable used to control reverse proxy IP addresses in Symfony 5 is called `TRUSTED_PROXIES`:
https://symfony.com/doc/current/deployment/proxies.html

This is also the variable we use in `index.php:
https://github.com/ezsystems/ezplatform/blob/master/public/index.php#L16

Yet we are still using in some places (Docker setup, webserver config templates) APP_TRUSTED_PROXIES, which can lead to configuration issues.

