### PR TITLE
Update comments about HttpCache purge type

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -39,7 +39,7 @@ parameters:
     purge_type: local
 
 ezplatform:
-    # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'http' you can point it to Varnish
+    # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'varnish' you can point it to Varnish
     http_cache:
         purge_type: '%purge_type%'
 
@@ -75,7 +75,7 @@ ezplatform:
                 # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
                 # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
                 default_ttl: '%httpcache_default_ttl%'
-            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
+            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'varnish'.
             http_cache:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'


### PR DESCRIPTION
This may be a minor forgotten non-updated misleading comment. 'http' is a value that can't be used anymore. It triggers the error "No driver found being able to handle purge_type 'http'."

During migration from v2.5.9 to v3.0.0-rc.1, I replace it with 'varnish' which seems OK.