### PR TITLE
EZP-31535: Replated deprecated Symfony\Component\Debug\Debug class 

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 use App\Kernel;
 use eZ\Bundle\EzPublishCoreBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31535

### Description

Replated deprecated `Symfony\Component\Debug\Debug` class by `Symfony\Component\ErrorHandler\Debug` in `bin/console.php`. 

See https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#debug