### PR TITLE
EZP-31541: Redis cache namespace is pulled from env variables

### DIFF
--- a/.env
+++ b/.env
@@ -47,6 +47,7 @@ CACHE_POOL=cache.tagaware.filesystem
 # - https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection
 # - https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection
 CACHE_DSN=localhost
+CACHE_NAMESPACE=ezp
 
 # eZ Platform HTTP Cache
 HTTPCACHE_DEFAULT_TTL=86400

--- a/config/packages/cache_pool/cache.redis.yaml
+++ b/config/packages/cache_pool/cache.redis.yaml
@@ -6,7 +6,7 @@
 # For further reading on setup with eZ Platform and Redis:
 # https://doc.ezplatform.com/en/latest/guide/persistence_cache/#redis
 parameters:
-  cache_namespace: ezp
+  cache_namespace: '%env(CACHE_NAMESPACE)%'
   cache_dsn: '%env(CACHE_DSN)%'
 
 services:


### PR DESCRIPTION
As a Developer, I want to be able to change Redis cache namespace using env variables: https://jira.ez.no/browse/EZP-31541