### PR TITLE
Better Github Integration using Github Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+| Q             | A
+| ------------- | ---
+| Branch?       | master / x.y.z
+| Bug fix?      | yes/no
+| New feature?  | yes/no <!-- don't forget updating docs/CHANGELOG.md files -->
+| BC breaks?    | yes/no
+| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
+
+<!--
+- Please fill in this template according to the PR you're about to submit.
+- Replace this comment by a description of what your PR is solving.
+-->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,14 @@
+| Q                | A
+| ---------------- | -----
+| Bug report?      | yes/no
+| Feature request? | yes/no
+| BC Break report? | yes/no
+| RFC?             | yes/no
+| Version          | x.y.z
+| Environment      | Linux/Mac/Windows
+
+
+<!--
+- Please fill in this template according to your issue.
+- And replace this comment by the description of your issue.
+-->

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -1,0 +1,143 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+    tests:
+        name: Tests
+        runs-on: ubuntu-latest
+        services:
+            mysql:
+                image: mariadb:10.3
+                env:
+                    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+                    MYSQL_DATABASE: ezplatform
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+            redis:
+                image: redis:latest
+                ports:
+                    - 6379:6379
+                options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        strategy:
+            matrix:
+                php: [7.3]
+        env:
+            CACHE_POOL: cache.redis
+            DATABASE_URL: mysql://root@127.0.0.1:3306/ezplatform
+            CACHE_DSN: 127.0.0.1:6379
+            APP_ENV: behat
+            APP_DEBUG: 1
+            COMPOSER_MEMORY_LIMIT: 4G
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@master
+                with:
+                    php-version: ${{ matrix.php }}
+                    extensions: mbstring, intl
+                id: php
+
+            -   name: Get Composer Cache Directory
+                id: composer-cache
+                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            -   uses: actions/cache@v1
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: |
+                        ${{ runner.os }}-composer-
+
+            -   name: Validate composer.json and composer.lock
+                run: composer validate
+
+            -   name: Install dependencies
+                run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
+
+            -   name: Show Versions
+                run: composer info -i
+
+            -   name: Install Symfony Server
+                run: |
+                    wget https://get.symfony.com/cli/installer -O - | bash
+                    /home/runner/.symfony/bin/symfony local:server:ca:install
+                    /home/runner/.symfony/bin/symfony local:php:list
+
+            -   name: Install eZ Platform
+                run: |
+                    rm -rf var/cache
+                    composer ezplatform-install
+
+            -   name: Run Webserver
+                run: /home/runner/.symfony/bin/symfony local:server:start --port=42443 -d
+
+            -   name: Change Mink Base Url
+                run: |
+                    sed -E 's/(base_url): '\''(http:\/\/localhost)'\''/\1: https:\/\/127.0.0.1:42443/g' behat.yml.dist > behat.yml
+
+            -   name: "eZ Platform REST Bundle functional tests"
+                run:  |
+                    bin/console ez:behat:create-language 'pol-PL' 'Polish (polski)'
+                    ./bin/.travis/run_rest_tests.sh
+                env:
+                    EZP_TEST_REST_HOST: 127.0.0.1:42443
+                    EZP_TEST_REST_SCHEME: https
+
+            -   name: "Kernel core tests"
+                run: bin/ezbehat --mode=behat --profile=core --tags=~@broken
+
+            -   name: "Behat"
+                run: bin/ezbehat --mode=behat --profile=behat --tags=~@broken
+
+            -   name: "Content Forms tests on Clean Platform"
+                run: bin/ezbehat --mode=behat --profile=content-forms --tags=~@broken --non-strict
+
+            -   name: "Admin UI on Clean Platform"
+                run: bin/ezbehat --profile=adminui --suite=adminui
+
+            -   name: "Admin UI tests using different personas"
+                run: |
+                    bin/ezbehat --profile=setup --suite=personas --tags=@setup
+                    bin/ezbehat --profile=adminui --suite=personas
+
+    varnishthroughezlaunchpad:
+        name: eZ Launchpad and HTTP Cache Tests
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                # This is PHP to run eZ Launchpad here, not the PHP running eZ
+                php: [7.3]
+        steps:
+            -   uses: actions/checkout@v1
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@master
+                with:
+                    php-version: ${{ matrix.php }}
+                id: php
+
+            -   name: Create fake conditions for eZ Launchpad - Create
+                run: |
+                    echo "{provisioning: { folder_name: provisioning}, docker: { compose_filename: docker-compose.yml, network_name: githubactions, network_prefix_port: 42}}" > ../.ezlaunchpad.yml
+                    mkdir ../data && cd ../data
+                    touch db.sql && gzip db.sql
+                    mkdir ezlaunchpad && cd ezlaunchpad
+                    wget -O ezlaunchpad.zip https://github.com/ezsystems/launchpad/archive/master.zip
+                    unzip ezlaunchpad.zip && rm ezlaunchpad.zip
+                    cp -rp launchpad-master/payload ../../provisioning
+                    cd .. && rm -rf ezlaunchpad
+
+            -   name: eZ Launchpad installation
+                run: curl -LSs https://ezsystems.github.io/launchpad/install_curl.bash | bash
+
+            -   name: eZ Launchpad create the project
+                run: cd .. && ~/ez create
+
+            -   name: Status Info
+                run:  cd .. && ~/ez ps
+
+            -   name: "Admin UI on Clean Platform with Varnish and Redis"
+                run: echo "@todo"

--- a/bin/.travis/run_rest_tests.sh
+++ b/bin/.travis/run_rest_tests.sh
@@ -2,5 +2,5 @@
 # Install REST package to get its dev dependencies and use them to run tests
 
 cd ./vendor/ezsystems/ezplatform-rest
-composer install
+composer install --prefer-dist --no-progress --no-suggest --no-interaction
 php ./vendor/bin/phpunit -c phpunit-integration-rest.xml


### PR DESCRIPTION

## Motivation

I have done this experiment, for 3 reasons:

- Github Actions is free for the community and faster than Travis, and I think that's the future.
- to simplify all the docker "things" this repository contains
- in order to simplify the `.env` later. Because it contains too much configuration unrelated to the application

In Bonus, I figured that it would be awesome to actually test eZ Platform with Varnish and Redis through eZ Launchpad!

**That would make so much sense.**

Then I have initiated it.

I took some liberties for now:

- No more Nginx for testing but Symfony Server: As Prod mode will be tested through eZ Launchpad.


## Questions

- Maybe eZ Launchpad should use the `vhost.sh` script. (unsure)
- Maybe eZ Launchpad should use the `varnish.vcl ` coming from `http-cache bundle`. (this one I am pretty sure)


## Todos

- [ ] Make tests working
- [x] Trick eZ Launchpad to `ez create` instead of `init`
- [ ] Trick eZ Launchpad for Solr to run.
- [ ] Make tests over Varnish working
- [ ] Clean .travis folder
- [ ] Remove `fail-fast: false`

What do you think? what is all that stuff regarding Docker in the repo?
I am sure it is all very interesting and that could benefit eZ Launchpad and vice-versa.
But I have never ever used what you have in the `docker` folder, where do you use it? internally?

I'll continue on making test works tonight,

Ping @andrerom, @bdunogier, @lserwatka @SylvainGuittard 

Let me know!
