### PR TITLE
EZP-31541: Added new CACHE_NAMESPACE env to redis docker stack

### DIFF
--- a/doc/docker/redis.yml
+++ b/doc/docker/redis.yml
@@ -12,6 +12,7 @@ services:
     environment:
      - CACHE_POOL=cache.redis
      - CACHE_DSN=redis:6379
+     - CACHE_NAMESPACE
 
   redis:
     image: ${REDIS_IMAGE}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-31541
followup to: https://github.com/ezsystems/ezplatform/pull/527