### PR TITLE
EZP-31550: [Behat] Added screenshot extensions

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -40,15 +40,15 @@ default:
 
         Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
 
-#        Bex\Behat\ScreenshotExtension:
-#            active_image_drivers: cloudinary
-#            image_drivers:
-#                cloudinary:
-#                    screenshot_directory: /tmp/behat-screenshot/
-#                    cloud_name: ezplatformtravis
-#                    preset: ezplatform
-#                    mode: normal
-#                    limit: 10
+        Bex\Behat\ScreenshotExtension:
+            active_image_drivers: cloudinary
+            image_drivers:
+                cloudinary:
+                    screenshot_directory: /tmp/behat-screenshot/
+                    cloud_name: ezplatformtravis
+                    preset: ezplatform
+                    mode: normal
+                    limit: 10
 
         Allure\Behat\AllureFormatterExtension: ~
 

--- a/composer.json
+++ b/composer.json
@@ -67,10 +67,9 @@
     "require-dev": {
         "behat/behat": "^3.6",
         "behat/mink": "^1.8",
-        "friends-of-behat/mink-extension": "^2.4",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
-        "friends-of-behat/symfony-extension": "^2.1@beta",
+        "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "ezsystems/allure-behat": "^3.1@dev",
@@ -78,11 +77,13 @@
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1@dev",
         "ezsystems/behatbundle": "^8.0@dev",
         "ezsystems/fastest": "^1.7",
+        "friends-of-behat/mink-extension": "^2.4",
+        "friends-of-behat/symfony-extension": "^2.1@beta",
         "overblog/graphiql-bundle": "^0.2",
+        "phpunit/phpunit": "^8.2",
         "symfony/debug-pack": "^1.0",
         "symfony/maker-bundle": "^1.14",
-        "symfony/test-pack": "^1.0",
-        "phpunit/phpunit": "^8.2"
+        "symfony/test-pack": "^1.0"
     },
     "conflict": {
         "doctrine/persistence": "1.3.2",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31550

The 2.1 release in `bex/behat-screenshot` adds support for Symfony 5:
https://github.com/elvetemedve/behat-screenshot/releases/tag/2.1.0

This PR:
1) adds the `bex/behat-screenshot` (also sorts existing packages, what we should be doing)
2) enables screenshot config again

Tested locally, it works as it used to:
```
Screenshot has been taken. Open image at https://res.cloudinary.com/ezplatformtravis/image/upload/v1586340203/screenshots/5e8da15a67d8d189055721-vendor_ezsystems_ezplatform-admin-ui_features_standard_authentication_feature_4_d4amv5.png
```