### PR TITLE
.env: Remove comment about parameters.yml

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,6 @@ DATABASE_PLATFORM=mysql
 DATABASE_DRIVER=pdo_mysql
 
 # Doctrine DBAL Schema
-# set here for BC reasons, change them in parameters.yml
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATION=utf8mb4_unicode_520_ci
 


### PR DESCRIPTION
[parameters.yml disappeared in Symfony 4 and environment variables seem recommanded.](http://fabien.potencier.org/symfony4-best-practices.html)

Maybe it's more an [application configuration](https://symfony.com/doc/5.0/best_practices.html#use-parameters-for-application-configuration) than an [environment variable](https://symfony.com/doc/5.0/best_practices.html#use-environment-variables-for-infrastructure-configuration) and the comment could be just updated to something like `# set here for BC reasons, change them in services.yaml`
