### PR TITLE
consistent formatting for yaml

### DIFF
--- a/config/packages/buzz.yaml
+++ b/config/packages/buzz.yaml
@@ -11,17 +11,17 @@ services:
     buzz.file_get_contents_client:
         class: Buzz\Client\FileGetContents
         arguments:
-            - timeout: 10
+            -   timeout: 10
 
     buzz.curl_client:
         class: Buzz\Client\Curl
         arguments:
-            - timeout: 10
+            -   timeout: 10
 
     buzz.multi_curl_client:
         class: Buzz\Client\MultiCurl
         arguments:
-            - timeout: 10
+            -   timeout: 10
 
     # Browser
     Buzz\Browser:

--- a/config/packages/cache_pool/cache.memcached.yaml
+++ b/config/packages/cache_pool/cache.memcached.yaml
@@ -10,15 +10,15 @@ services:
         public: true
         parent: cache.adapter.memcached
         tags:
-            - name: cache.pool
-              clearer: cache.app_clearer
-              # Example from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/MemcachedTrait.php:
-              # memcached://user:pass@localhost?weight=33'
-              provider: 'memcached://%cache_dsn%'
-              # Cache namespace prefix overriding the one used by Symfony globally
-              # This makes sure cache is reliably shared across whole cluster and all Symfony env's
-              # Can be used for blue/green deployment strategies when changes affect content cache.
-              # For multi db setup adapt this to be unique per pool (one pool per database)
-              # If you prefer default behaviour set this to null or comment out, and consider for instance:
-              # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
-              namespace: '%cache_namespace%'
+            -   name: cache.pool
+                clearer: cache.app_clearer
+                # Example from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/MemcachedTrait.php:
+                # memcached://user:pass@localhost?weight=33'
+                provider: 'memcached://%cache_dsn%'
+                # Cache namespace prefix overriding the one used by Symfony globally
+                # This makes sure cache is reliably shared across whole cluster and all Symfony env's
+                # Can be used for blue/green deployment strategies when changes affect content cache.
+                # For multi db setup adapt this to be unique per pool (one pool per database)
+                # If you prefer default behaviour set this to null or comment out, and consider for instance:
+                # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
+                namespace: '%cache_namespace%'

--- a/config/packages/cache_pool/cache.redis.yaml
+++ b/config/packages/cache_pool/cache.redis.yaml
@@ -6,8 +6,8 @@
 # For further reading on setup with eZ Platform and Redis:
 # https://doc.ezplatform.com/en/latest/guide/persistence_cache/#redis
 parameters:
-  cache_namespace: '%env(CACHE_NAMESPACE)%'
-  cache_dsn: '%env(CACHE_DSN)%'
+    cache_namespace: '%env(CACHE_NAMESPACE)%'
+    cache_dsn: '%env(CACHE_DSN)%'
 
 services:
     cache.redis:
@@ -15,18 +15,18 @@ services:
         class: Symfony\Component\Cache\Adapter\RedisTagAwareAdapter
         parent: cache.adapter.redis
         tags:
-            - name: cache.pool
-              clearer: cache.app_clearer
-              # Examples from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/RedisTrait.php:
-              # redis://localhost:6379
-              # redis://secret@example.com:1234/13
-              # redis://secret@/var/run/redis.sock/13?persistent_id=4&class=Redis&timeout=3&retry_interval=3
-              # Example using Predis: redis://%cache_dsn%?class=\Predis\Client
-              provider: 'redis://%cache_dsn%'
-              # Cache namespace prefix overriding the one used by Symfony by default
-              # This makes sure cache is reliably shared across whole cluster and all Symfony env's
-              # Can be used for blue/green deployment strategies when changes affect content cache.
-              # For multi db setup adapt this to be unique per pool (one pool per database)
-              # If you prefer default behaviour set this to null or comment out, and consider for instance:
-              # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
-              namespace: '%cache_namespace%'
+            -   name: cache.pool
+                clearer: cache.app_clearer
+                # Examples from vendor/symfony/symfony/src/Symfony/Component/Cache/Traits/RedisTrait.php:
+                # redis://localhost:6379
+                # redis://secret@example.com:1234/13
+                # redis://secret@/var/run/redis.sock/13?persistent_id=4&class=Redis&timeout=3&retry_interval=3
+                # Example using Predis: redis://%cache_dsn%?class=\Predis\Client
+                provider: 'redis://%cache_dsn%'
+                # Cache namespace prefix overriding the one used by Symfony by default
+                # This makes sure cache is reliably shared across whole cluster and all Symfony env's
+                # Can be used for blue/green deployment strategies when changes affect content cache.
+                # For multi db setup adapt this to be unique per pool (one pool per database)
+                # If you prefer default behaviour set this to null or comment out, and consider for instance:
+                # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
+                namespace: '%cache_namespace%'

--- a/config/packages/cache_pool/cache.tagaware.filesystem.yaml
+++ b/config/packages/cache_pool/cache.tagaware.filesystem.yaml
@@ -2,7 +2,7 @@
 #
 # Loaded by default, for use on single server setups.
 parameters:
-  cache_namespace: ezp
+    cache_namespace: ezp
 
 services:
     cache.tagaware.filesystem:
@@ -10,12 +10,12 @@ services:
         class: Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter
         parent: cache.adapter.filesystem
         tags:
-            - name: cache.pool
-              clearer: cache.app_clearer
-              # Cache namespace prefix overriding the one used by Symfony by default
-              # This makes sure cache is reliably shared across whole cluster and all Symfony env's
-              # Can be used for blue/green deployment strategies when changes affect content cache.
-              # For multi db setup adapt this to be unique per pool (one pool per database)
-              # If you prefer default behaviour set this to null or comment out, and consider for instance:
-              # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
-              namespace: '%cache_namespace%'
+            -   name: cache.pool
+                clearer: cache.app_clearer
+                # Cache namespace prefix overriding the one used by Symfony by default
+                # This makes sure cache is reliably shared across whole cluster and all Symfony env's
+                # Can be used for blue/green deployment strategies when changes affect content cache.
+                # For multi db setup adapt this to be unique per pool (one pool per database)
+                # If you prefer default behaviour set this to null or comment out, and consider for instance:
+                # https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
+                namespace: '%cache_namespace%'

--- a/config/packages/ezplatform_http_cache.yaml
+++ b/config/packages/ezplatform_http_cache.yaml
@@ -3,8 +3,7 @@ fos_http_cache:
     cache_control:
         rules:
             # Make sure already cacheable (fresh) responses from eZ Platform which are errors/redirect gets lower ttl (then default_ttl)
-            -
-                match:
+            -   match:
                     match_response: "response.isFresh() && ( response.isServerError() || response.isClientError() || response.isRedirect() )"
                 headers:
                     overwrite: true
@@ -13,8 +12,7 @@ fos_http_cache:
                         s_maxage: 20
             # Example of performance tuning, force TTL on 404 pages to avoid crawlers / ... taking to much load
             # Should not be set to high, as cached 404's can cause issues for future routes, url aliases, wildcards, ..
-            -
-                match:
+            -   match:
                     match_response: "!response.isFresh() && response.isNotFound()"
                 headers:
                     overwrite: true

--- a/config/packages/graphql.yaml
+++ b/config/packages/graphql.yaml
@@ -3,7 +3,6 @@ overblog_graphql:
         mappings:
             auto_discover: false
             types:
-                -
-                    type: yaml
+                -   type: yaml
                     dir: "%kernel.project_dir%/config/graphql/types"
                     suffix: ~


### PR DESCRIPTION
Use 4 spaces indention (per Symfony coding standards).
Switch from "sequence on a new line" to "sequence on the same line".
