### PR TITLE
[Docker] Changed install-dependencies to rely on PHP_IMAGE variable

### DIFF
--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -3,7 +3,7 @@ version: '3.3'
 
 services:
   install_dependencies:
-    image: ${PHP_IMAGE_DEV}
+    image: ${PHP_IMAGE}-dev
     volumes:
      - ${COMPOSE_DIR}/../..:/var/www:cached
      - ${COMPOSER_HOME}:/root/.composer:cached


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31579

Currently the `install-dependencies` container relies on PHP_IMAGE_DEV env variable.

For me this is confusing and leads to errors - it's not enough to specify PHP_IMAGE, but PHP_IMAGE_DEV is required.

Example error:
https://github.com/ezsystems/ezplatform-http-cache/blob/1.0/.travis.yml#L26 - only PHP_IMAGE is specified, but PHP_IMAGE_DEV is not.
This fails on Travis: https://travis-ci.org/github/ezsystems/ezplatform-http-cache/jobs/674863009
because the packages are installed using PHP 7.3, but tests are run using PHP7.1.

To avoid this confusion I think install-dependencies should rely on PHP_IMAGE variable.