### PR TITLE
EZP-31603: Replaced TRUST_REMOTE with REMOTE_ADDR

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -44,7 +44,7 @@ variables:
         # We disable Symfony Proxy (CacheKernel), as we rather use Varnish
         APP_HTTP_CACHE: 0
         # Warning: Only for Varnish on Platform.sh to workaround missing IP. Disable if you use Fastly or Symfony Proxy where this would be a security issue!
-        TRUSTED_PROXIES: "TRUST_REMOTE"
+        TRUSTED_PROXIES: "REMOTE_ADDR"
         # Change this if you use a different env than "prod"
         # If you change to "dev" remove "--no-dev" from the `composer install` command.
         APP_ENV: prod


### PR DESCRIPTION
As additional debuging for https://github.com/ezsystems/ezplatform-http-cache/pull/129, shown `TRUST_REMOTE` is no longer handled by front controller, in a way it was done in 2.5.

in 2.5 `app.php` there was following piece of code, which is now missing in 3.0.
```php
if ($trustedProxies = getenv('SYMFONY_TRUSTED_PROXIES')) {
    if ($trustedProxies === 'TRUST_REMOTE') {
        Request::setTrustedProxies([$request->server->get('REMOTE_ADDR')], Request::HEADER_X_FORWARDED_ALL);
    } else {
        Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
    }
}
```
but, as we dont want to add stuff to index.php in termx of `flex` complaiance (correct me if I am wrong @webhdx) I think above logic can be handled in Symfony Request object itself, as since symfony 4.4, there is following logic in it

```php
if ('REMOTE_ADDR' !== $proxy) {
    $proxies[] = $proxy;
} elseif (isset($_SERVER['REMOTE_ADDR'])) {
    $proxies[] = $_SERVER['REMOTE_ADDR'];
}
```

https://github.com/symfony/http-foundation/blob/4.4/Request.php#L583

so basically it adds `$request->server->get('REMOTE_ADDR')` from old logic into list of trusted proxies.