### PR TITLE
[BEHAT] Updated selenium container to 20200326 version

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ PHP_IMAGE=ezsystems/php:7.3-v1
 PHP_IMAGE_DEV=ezsystems/php:7.3-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
-SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-oxygen
+SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-20200326
 REDIS_IMAGE=healthcheck/redis
 
 APP_DOCKER_FILE=doc/docker/Dockerfile-app

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -16,6 +16,7 @@ default:
                 capabilities:
                     extra_capabilities:
                         chromeOptions:
+                            w3c: false
                             args:
                                 - "--window-size=1440,1080"
                                 - "--no-sandbox"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31549

We have started getting invalid argument: 'id' can not be string errors, while testing the newest selenium image (20200326). Solution to this problem was adding a new line in behat.yml.dist ChromeOptions (w3c: false).
It is a known problem and it seems its not yet fixed for Mink - ref.

1. https://medium.com/@alex.designworks/chromedriver-75-enforces-w3c-standard-breaking-behat-tests-460cad435545
2. minkphp/MinkSelenium2Driver#293

Potential solution - php-webdriver/php-webdriver#560