### PR TITLE
[Platform.sh] Only enable Solr if parameter 'search_engine' is 'solr'

### DIFF
--- a/config/packages/overrides/platformsh.php
+++ b/config/packages/overrides/platformsh.php
@@ -105,7 +105,10 @@ if (isset($relationships['redissession'])) {
     }
 }
 
-if (isset($relationships['solr'])) {
+if (
+    isset($relationships['solr']) &&
+    (!$container->hasParameter('search_engine') || $container->getParameter('search_engine') === 'solr')
+) {
     foreach ($relationships['solr'] as $endpoint) {
         if ($endpoint['scheme'] !== 'solr') {
             continue;


### PR DESCRIPTION
If there is a Platform.sh Solr relationship, but the project config is not set to use the "solr" search engine (i.e. it's set to "legacy", or not set at all), then the Solr params shouldn't be set here.