### PR TITLE
Platform.sh: allow to use HTTP access credentials for Varnish

### DIFF
--- a/config/packages/overrides/platformsh.php
+++ b/config/packages/overrides/platformsh.php
@@ -137,7 +137,7 @@ if ($route !== null && !($_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false)) {
     $purgeServer = rtrim($route, '/');
     if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
         $domain = parse_url($purgeServer, \PHP_URL_HOST);
-        $credentials = $_SERVER['HTTPCACHE_USERNAME'] . ':' . urlencode($_SERVER['HTTPCACHE_PASSWORD']);
+        $credentials = urlencode($_SERVER['HTTPCACHE_USERNAME']) . ':' . urlencode($_SERVER['HTTPCACHE_PASSWORD']);
         $purgeServer = str_replace($domain, $credentials . '@' . $domain, $purgeServer);
     }
 

--- a/config/packages/overrides/platformsh.php
+++ b/config/packages/overrides/platformsh.php
@@ -134,10 +134,16 @@ foreach ($routes as $host => $info) {
 }
 
 if ($route !== null && !($_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false)) {
-    $container->setParameter('purge_type', 'varnish');
-    $container->setParameter('purge_server', rtrim($route, '/'));
-}
+    $purgeServer = rtrim($route, '/');
+    if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
+        $domain = parse_url($purgeServer, \PHP_URL_HOST);
+        $credentials = $_SERVER['HTTPCACHE_USERNAME'] . ':' . urlencode($_SERVER['HTTPCACHE_PASSWORD']);
+        $purgeServer = str_replace($domain, $credentials . '@' . $domain, $purgeServer);
+    }
 
+    $container->setParameter('purge_type', 'varnish');
+    $container->setParameter('purge_server', $purgeServer);
+}
 // Setting default value for HTTPCACHE_VARNISH_INVALIDATE_TOKEN if it is not explicitly set
 if (!($_SERVER['HTTPCACHE_VARNISH_INVALIDATE_TOKEN'] ?? false)) {
     $container->setParameter('varnish_invalidate_token', $_SERVER['PLATFORM_PROJECT_ENTROPY']);


### PR DESCRIPTION
We are working on eZ Platform v3 upgrade on a Platform.sh environment. And we are using Varnish. Platform.sh environment we are using for has enabled HTTP Access control. Which means we get 401 response code when Varnish cache is purged. It happened more than once, and we decided to share our solution:

1. Setup `HTTPCACHE_USERNAME` and `HTTPCACHE_PASSWORD` variables in Platform.sh environment, which will store HTTTP Access control credentials:
    ```
    PSH_ENV=ezplatform3ee
    HTTP_ACCESS_USER=user
    HTTP_ACCESS_PASSWORD=password
    
    platform variable:create --level=environment --environment=${PSH_ENV} --name=HTTPCACHE_USERNAME --value=${HTTP_ACCESS_USER} --json=false --sensitive=false --prefix=env --visible-build=true --visible-runtime=true --enabled=true --inheritable=false
    platform variable:create --level=environment --environment=${PSH_ENV} --name=HTTPCACHE_PASSWORD --value=${HTTP_ACCESS_PASSWORD} --json=false --sensitive=true --prefix=env --visible-build=true --visible-runtime=true --enabled=true --inheritable=false
    ```

2. Implement the changes from this PR

**Please note**: this PR depends on https://github.com/FriendsOfSymfony/FOSHttpCache/pull/480