### PR TITLE
Bring back SYMFONY_TMP_DIR (in another form) for Docker optimization

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -46,4 +46,19 @@ class Kernel extends BaseKernel
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
     }
+
+    // can be removed when bumping to Symfony 5.2
+    public function getCacheDir()
+    {
+        if (isset($_SERVER['APP_CACHE_DIR'])) {
+            return $_SERVER['APP_CACHE_DIR'].'/'.$this->environment;
+        }
+        return parent::getCacheDir();
+    }
+
+    // can be removed when bumping to Symfony 5.2
+    public function getLogDir()
+    {
+        return $_SERVER['APP_LOG_DIR'] ?? parent::getLogDir();
+    }
 }


### PR DESCRIPTION
There is a slack discussion in #ez-launchpad.
But I prefer to open that PR to the community.

Without this, there is no way to tell Docker to save the Symfony cache in the container rather than in the host.

On Mac OS this is a performance killer.

On 2.5 we still have it, why has it been removed?
https://github.com/ezsystems/ezplatform/blob/2.5/app/AppKernel.php#L84

Thanks!

