### PR TITLE
[Platform.sh] Changed default version of Solr to 7.7

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -57,7 +57,7 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:6.6
+#    type: solr:7.7
 #    disk: 512
 #    configuration:
 #        configsets:


### PR DESCRIPTION
Changing the default version of Solr used on Platform.sh to 7.7.

The current Solr instruction for Platform.sh states:
```
# If you wish to use solr, uncomment this service and the corresponding relationship in .platform.app.yaml.
# Also, you need to generate the config using:
# vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh
# Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
# unable to reach each other
```

But it's not working out of the box, because the `generate-config` script does not support Solr 6.6: https://github.com/ezsystems/ezplatform-solr-search-engine/blob/3.0/bin/generate-solr-config.sh#L31 (which is the version used by default).

After changing to 7.7 everything works as expected.

7.7 is the recommended version to use with solr-bundle 3.0: https://github.com/ezsystems/ezplatform-solr-search-engine/blob/3.0/README.md
and is supported by Platform.sh: https://docs.platform.sh/configuration/services/solr.html

The only issue I see here could be related to upgrades - people upgrading from v2 to v3 will have to adapt their config manually (and refer to https://docs.platform.sh/configuration/services/solr.html#upgrading), should we mention it somewhere?