### PR TITLE
[Travis] Check if downloaded docker-compose is an application

### DIFF
--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -24,9 +24,15 @@ if (( $(echo "$dc < 1.23" |bc -l) )); then
     DOCKER_COMPOSE_VERSION="1.23.2"
     echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"
     sudo rm -f /usr/local/bin/docker-compose
-    curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-    chmod +x docker-compose
-    sudo mv docker-compose /usr/local/bin
+    curl --retry 5 -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    FILE_TYPE=$(file -b --mime-type docker-compose | sed 's|/.*||')
+    if [[ $FILE_TYPE == "application" ]]; then
+        chmod +x docker-compose
+        sudo mv docker-compose /usr/local/bin
+    else
+        echo "Error when downloading docker-compose"
+        cat docker-compose
+    fi
 else
     echo "Skip updating Docker Compose ${dc} (${dc_full})"
 fi


### PR DESCRIPTION
We have builds failing with:
```
> Install DB and dependencies

/usr/local/bin/docker-compose: line 1: syntax error near unexpected token `newline'

/usr/local/bin/docker-compose: line 1: `<html>'
home/travis/.travis/functions: line 109: cd: /home/travis/build/ezplatform: No such file or directory
/usr/local/bin/docker-compose: line 1: syntax error near unexpected token `newline'
/usr/local/bin/docker-compose: line 1: `<html>'
```
Example failure: https://travis-ci.org/github/ezsystems/ezplatform/jobs/689872600

Mu current guess is that the command
```
curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
```
sometimes returns an HTML error page instead of an application, which cause us to use an HTML page as an executable later in the script.

Something similar: https://github.com/docker/compose/issues/3149

I've tried reproducing the issue in this PR (hence all the commits), but I was not able to - I'd keep the `cat docker-compose` line so that once it occurs we will be able to debug it a bit more.

TO DO before merging:
- [ ] clean up commits