### PR TITLE
Add error routes in dev environment

### DIFF
--- a/config/routes/dev/framework.yaml
+++ b/config/routes/dev/framework.yaml
@@ -1,0 +1,3 @@
+_errors:
+    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+    prefix: /_error


### PR DESCRIPTION
Enables usage of `/_error/xyz` route in dev environments.