### PR TITLE
[Composer] Added conflict with symfony/framework-bundle 5.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
     },
     "conflict": {
         "doctrine/persistence": "1.3.2",
+        "symfony/framework-bundle": "5.1.0",
         "symfony/symfony": "*"
     },
     "replace": {


### PR DESCRIPTION
Framework bundle 5.1.0 has a change incompatible with our code: https://github.com/symfony/symfony/issues/37042

We need to wait until it's fixed, so I'm adding a conflict with that version (hoping that it will be fixed in 5.1.1).