### PR TITLE
Flex switched to 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "symfony/console": "^5.0",
         "symfony/dotenv": "^5.0",
         "symfony/expression-language": "^5.0",
-        "symfony/flex": "^1.6",
+        "symfony/flex": "^1.7",
         "symfony/form": "^5.0",
         "symfony/framework-bundle": "^5.0",
         "symfony/monolog-bundle": "^3.5",


### PR DESCRIPTION
`symfony/flex` updated to `^1.7` (it was `^1.6` before).