### PR TITLE
[Travis] Switched to Github API when downloading docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 language: generic
 
 services:

--- a/bin/.travis/trusty/update_curl.sh
+++ b/bin/.travis/trusty/update_curl.sh
@@ -6,9 +6,9 @@ sudo apt-get build-dep curl
 # Get latest (as of Feb 25, 2016) libcurl
 mkdir ~/curl
 cd ~/curl
-wget http://curl.haxx.se/download/curl-7.50.2.tar.bz2
-tar -xvjf curl-7.50.2.tar.bz2
-cd curl-7.50.2
+wget http://curl.haxx.se/download/curl-7.64.1.tar.bz2
+tar -xvjf curl-7.64.1.tar.bz2
+cd curl-7.64.1
 
 # The usual steps for building an app from source
 # ./configure

--- a/bin/.travis/trusty/update_curl.sh
+++ b/bin/.travis/trusty/update_curl.sh
@@ -21,3 +21,5 @@ sudo make install
 # Resolve any issues of C-level lib
 # location caches ("shared library cache")
 sudo ldconfig
+
+curl -V

--- a/bin/.travis/trusty/update_curl.sh
+++ b/bin/.travis/trusty/update_curl.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+# Install any build dependencies needed for curl
+sudo apt-get build-dep curl
+
+# Get latest (as of Feb 25, 2016) libcurl
+mkdir ~/curl
+cd ~/curl
+wget http://curl.haxx.se/download/curl-7.50.2.tar.bz2
+tar -xvjf curl-7.50.2.tar.bz2
+cd curl-7.50.2
+
+# The usual steps for building an app from source
+# ./configure
+# ./make
+# sudo make install
+./configure
+make
+sudo make install
+
+# Resolve any issues of C-level lib
+# location caches ("shared library cache")
+sudo ldconfig

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -27,7 +27,14 @@ if (( ! $(echo "$dc < 1.23" |bc -l) )); then
     exit 0
 fi
 
-sudo apt-get update curl
+wget http://curl.haxx.se/download/curl-7.60.0.tar.bz2
+tar -xvjf curl-7.60.0.tar.bz2
+cd curl-7.60.0
+./configure
+make
+sudo make install
+sudo ldconfig
+
 
 DOCKER_COMPOSE_VERSION="1.23.2"
 echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -27,6 +27,8 @@ if (( ! $(echo "$dc < 1.23" |bc -l) )); then
     exit 0
 fi
 
+sudo apt-get update curl
+
 DOCKER_COMPOSE_VERSION="1.23.2"
 echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"
 GITHUB_TOKEN=$(cat ${SCRIPT_DIR}/../composer-auth.json | jq -r '.["github-oauth"]["github.com"]')

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -29,6 +29,8 @@ fi
 
 $SCRIPT_DIR/update_curl.sh
 
+curl -V
+
 DOCKER_COMPOSE_VERSION="1.23.2"
 echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"
 GITHUB_TOKEN=$(cat ${SCRIPT_DIR}/../composer-auth.json | jq -r '.["github-oauth"]["github.com"]')

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -34,7 +34,7 @@ cd curl-7.60.0
 make
 sudo make install
 sudo ldconfig
-
+cd ..
 
 DOCKER_COMPOSE_VERSION="1.23.2"
 echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -27,14 +27,7 @@ if (( ! $(echo "$dc < 1.23" |bc -l) )); then
     exit 0
 fi
 
-wget http://curl.haxx.se/download/curl-7.60.0.tar.bz2
-tar -xvjf curl-7.60.0.tar.bz2
-cd curl-7.60.0
-./configure
-make
-sudo make install
-sudo ldconfig
-cd ..
+$SCRIPT_DIR/update_curl.sh
 
 DOCKER_COMPOSE_VERSION="1.23.2"
 echo "Updating Docker Compose from ${dc} (${dc_full}) to ${DOCKER_COMPOSE_VERSION}"

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -38,13 +38,12 @@ PLATFORM=docker-compose-`uname -s`-`uname -m`
 
 DOCKER_COMPOSE_DOWNLOAD_URL=$(curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/docker/compose/releases/tags/${DOCKER_COMPOSE_VERSION} | jq -r --arg p "$PLATFORM" '.assets[] | select(.name == $p) | .url')
 echo "Downloading docker-compose from ${DOCKER_COMPOSE_DOWNLOAD_URL}"
-curl -v -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" -L ${DOCKER_COMPOSE_DOWNLOAD_URL} --output docker-compose-dl
+curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" -L ${DOCKER_COMPOSE_DOWNLOAD_URL} --output docker-compose-dl
 
 FILE_TYPE=$(file -b --mime-type docker-compose-dl | sed 's|/.*||')
 if [[ $FILE_TYPE == "application" ]]; then
     sudo rm -f /usr/local/bin/docker-compose
     chmod +x docker-compose-dl
-    cat docker-compose-dl
     sudo mv docker-compose-dl /usr/local/bin/docker-compose
 else
     echo "Error when downloading docker-compose"

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -34,7 +34,7 @@ PLATFORM=docker-compose-`uname -s`-`uname -m`
 
 DOCKER_COMPOSE_DOWNLOAD_URL=$(curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/docker/compose/releases/tags/${DOCKER_COMPOSE_VERSION} | jq -r --arg p "$PLATFORM" '.assets[] | select(.name == $p) | .url')
 echo "Downloading docker-compose from ${DOCKER_COMPOSE_DOWNLOAD_URL}"
-curl -L -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" $DOCKER_COMPOSE_DOWNLOAD_URL > docker-compose-dl
+curl -I -v -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" -L ${DOCKER_COMPOSE_DOWNLOAD_URL} --output docker-compose-dl
 
 FILE_TYPE=$(file -b --mime-type docker-compose-dl | sed 's|/.*||')
 if [[ $FILE_TYPE == "application" ]]; then

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -33,12 +33,14 @@ GITHUB_TOKEN=$(cat ${SCRIPT_DIR}/../composer-auth.json | jq -r '.["github-oauth"
 PLATFORM=docker-compose-`uname -s`-`uname -m`
 
 DOCKER_COMPOSE_DOWNLOAD_URL=$(curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/docker/compose/releases/tags/${DOCKER_COMPOSE_VERSION} | jq -r --arg p "$PLATFORM" '.assets[] | select(.name == $p) | .url')
+echo "Downloading docker-compose from ${DOCKER_COMPOSE_DOWNLOAD_URL}"
 curl -L -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" $DOCKER_COMPOSE_DOWNLOAD_URL > docker-compose-dl
 
 FILE_TYPE=$(file -b --mime-type docker-compose-dl | sed 's|/.*||')
 if [[ $FILE_TYPE == "application" ]]; then
     sudo rm -f /usr/local/bin/docker-compose
     chmod +x docker-compose-dl
+    cat docker-compose-dl
     sudo mv docker-compose-dl /usr/local/bin/docker-compose
 else
     echo "Error when downloading docker-compose"

--- a/bin/.travis/trusty/update_docker.sh
+++ b/bin/.travis/trusty/update_docker.sh
@@ -34,7 +34,7 @@ PLATFORM=docker-compose-`uname -s`-`uname -m`
 
 DOCKER_COMPOSE_DOWNLOAD_URL=$(curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/docker/compose/releases/tags/${DOCKER_COMPOSE_VERSION} | jq -r --arg p "$PLATFORM" '.assets[] | select(.name == $p) | .url')
 echo "Downloading docker-compose from ${DOCKER_COMPOSE_DOWNLOAD_URL}"
-curl -I -v -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" -L ${DOCKER_COMPOSE_DOWNLOAD_URL} --output docker-compose-dl
+curl -v -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" -L ${DOCKER_COMPOSE_DOWNLOAD_URL} --output docker-compose-dl
 
 FILE_TYPE=$(file -b --mime-type docker-compose-dl | sed 's|/.*||')
 if [[ $FILE_TYPE == "application" ]]; then


### PR DESCRIPTION
As described in https://github.com/ezsystems/ezplatform/pull/547#issuecomment-639294655 we're sometimes triggering GitHub's abuse detection mechanism when upgrading docker-compose.

Failing job: https://travis-ci.org/github/ezsystems/ezplatform/jobs/694872094
GitHub response:
```
<html>
  <head>
    <meta content="origin" name="referrer">
    <title>Rate limit &middot; GitHub</title>
    <meta name="viewport" content="width=device-width">
    <style type="text/css" media="screen">
      body {
        background-color: #f6f8fa;
        color: rgba(0, 0, 0, 0.5);
        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
        font-size: 14px;
        line-height: 1.5;
      }
      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
      a { text-decoration: none; }
      a:hover { text-decoration: underline; }
      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
      p { margin: 20px 0 40px; }
      #s { margin-top: 35px; }
      #s a {
        color: #666666;
        font-weight: 200;
        font-size: 14px;
        margin: 0 10px;
      }
    </style>
  </head>
  <body>
    <div class="c">
      <h1>Whoa there!</h1>
      <p>You have triggered an abuse detection mechanism.<br><br>
        Please wait a few minutes before you try again;<br>
        in some cases this may take up to an hour.
      </p>
      <div id="s">
        <a href="https://support.github.com">Contact Support</a> &mdash;
        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
        <a href="https://twitter.com/githubstatus">@githubstatus</a>
      </div>
    </div>
  </body>
</html>
```

This PR changes how the release is downloaded - not from a website (even though it's the recommended by in Docker doc: https://docs.docker.com/compose/install/#install-compose-on-linux-systems) but with REST API. 

Using REST gives us the possibility to authenticate (using the `Authentication` header), which allows to use to send 5000 requests/hour. I hope this will be enough - as the current approach is not using REST I don't think it's possible to authenticate there somehow.

Used endpoints:
https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
https://developer.github.com/v3/repos/releases/#get-a-release-asset

Failing because of: https://stackoverflow.com/questions/37865875/stopping-curl-from-sending-authorization-header-on-302-redirect (curl version on trusty is too low by default)
Used: https://gist.github.com/fideloper/f72997d2e2c9fbe66459