### PR TITLE
[Composer] Added direct requirement for doctrine/doctrine-migrations-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^7.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/doctrine-migrations-bundle": "^2.1",
         "ezsystems/doctrine-dbal-schema": "~1.0.0@dev",
         "ezsystems/ez-support-tools": "~2.0.0@dev",
         "ezsystems/ezplatform-admin-ui": "~2.0.0@dev",


### PR DESCRIPTION
The config in meta we have right now:
https://github.com/ezsystems/ezplatform/blob/master/config/packages/doctrine_migrations.yaml
is meant for doctrine/doctrine-migrations-bundle ^2.0 and is not compatible with the 3.0 version released yesterday. This metarepo fails to finish `composer install` with:
```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In ArrayNode.php line 320:
!!
!!    Unrecognized options "dir_name, namespace" under "doctrine_migrations". Ava
!!    ilable options are "all_or_nothing", "check_database_platform", "connection
!!    ", "custom_template", "em", "factories", "migrations", "migrations_paths",
!!    "organize_migrations", "services", "storage".
!!
```

Adding a direct requirement for doctrine/doctrine-migrations-bundle to keep everything working (until we decide we can safely migrate to doctrine/doctrine-migrations-bundle:^3.0)