### PR TITLE
EZP-28916: [Varnish] Only Vary on X-User-Context-Hash when asked to by controllers

### DIFF
--- a/config/packages/ezplatform_http_cache.yaml
+++ b/config/packages/ezplatform_http_cache.yaml
@@ -2,10 +2,11 @@
 fos_http_cache:
     # https://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/user-context.html#configuration
     user_context:
-        # As of eZ Platform v3.1 we ship with this disabled by default for better cache efficiency (EZP-28916).
-        # BC BREAK: For upgrades you might want to omit it, as it implies all custom
-        # controllers that relies on user rights needs an explicit: $response->setVary('X-User-Context-Hash');
+        # As of eZ Platform v3.2 we ship with this disabled by default for better cache efficiency (EZP-28916).
+        # UPGRADE NOTE: For upgrades you might want to omit it, as it implies *all* custom controllers
+        #               that relies on user rights needs an explicit: $response->setVary('X-User-Context-Hash');
         always_vary_on_context_hash: false
+
     # https://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/headers.html
     cache_control:
         rules:

--- a/config/packages/ezplatform_http_cache.yaml
+++ b/config/packages/ezplatform_http_cache.yaml
@@ -1,5 +1,12 @@
 ## FOSHttpCache Configuration
 fos_http_cache:
+    # https://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/user-context.html#configuration
+    user_context:
+        # As of eZ Platform v3.1 we ship with this disabled by default for better cache efficiency (EZP-28916).
+        # BC BREAK: For upgrades you might want to omit it, as it implies all custom
+        # controllers that relies on user rights needs an explicit: $response->setVary('X-User-Context-Hash');
+        always_vary_on_context_hash: false
+    # https://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/headers.html
     cache_control:
         rules:
             # Make sure already cacheable (fresh) responses from eZ Platform which are errors/redirect gets lower ttl (then default_ttl)


### PR DESCRIPTION
See: https://jira.ez.no/browse/EZP-28916

Details: Disables default behavior where FOSHttpCache adds `Vary: X-User-Context-Hash` whenever the `X-User-Context-Hash` header is part of request. Meaning ALWAYS on Varnish/Fastly, which can only provide the hash value by means of request header.

- *Pro*: Makes sure only responses that explicitly vary on `X-User-Context-Hash` will vary on it _(set in controller or otherwise)_.
    - This improves hit ratio, and saves memory usage in Varnish/Fastly as it will only vary on user permissions if needed instead of for everything served by PHP.

- *Con*: Code _(typically custom controllers, not part of content view)_ that has relied on this being auto added will break, as in you can end up getting cache for another user as it won't vary for you on custom controllers

Hence why this is suggested to only be a best practice meta config change, so people can decide themselves when upgrading.