### PR TITLE
[Behat] Limited fastest version to ~1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "ezsystems/allure-php-api": "^2.0@dev",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0@dev",
         "ezsystems/behatbundle": "^7.0.0@dev",
-        "liuggio/fastest": "^1.6",
+        "liuggio/fastest": "~1.6.0",
         "overblog/graphiql-bundle": "^0.1.2",
         "phpunit/phpunit": "^6.5.13",
         "sensio/generator-bundle": "^3.1.7",


### PR DESCRIPTION
Release v1.7.0 in fastest fixed the issue with queue order:
https://github.com/liuggio/fastest/releases/tag/v1.7.0
https://github.com/liuggio/fastest/issues/135

for which we have a workaround in BehatBundle:
https://github.com/ezsystems/BehatBundle/blob/7.0/bin/ezbehat#L57

But the new version (with the fix) is available only for PHP7.2 or higher, meaning that we can't use it in all jobs running tests on v2 (the lowest supported version is 7.1). Since our workaround cannot support both fastest versions at the same time (one will have invalid behaviour) we need to decide on one, in this case a version supported by the lowest version possible on v2 - hence ~1.6.0 requirement.

This requirement is valid only for 2.5 branch, in 3.0 and master it's not needed.

### How does the issue manifest itself?
Tests are run in incorrect order, you can compare the same tests suite for different PHP versions in https://travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/172936937

the job running PHP7.1 starts with `1/26	✔	24 min 32 s 141 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentTypeFields.feature` - this is the correct order
the job running PHP7.4 starts with `1/26	✔	18 s 814 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/SearchContent.feature` and `ContentTypeFields` feature is the last - this is the worst order for us

Somewhat similar PR: https://github.com/ezsystems/BehatBundle/pull/136
