### PR TITLE
[docker] Disable xdebug while installing deps

### DIFF
--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -18,4 +18,4 @@ services:
      - COMPOSER_AUTH
      - DATABASE_PLATFORM
      - DATABASE_PORT
-    command: ./doc/docker/install_script.sh
+    command: sh -c "rm /usr/local/etc/php/conf.d/xdebug.ini && ./doc/docker/install_script.sh"

--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -18,4 +18,4 @@ services:
      - COMPOSER_AUTH
      - DATABASE_PLATFORM
      - DATABASE_PORT
-    command: sh -c "rm /usr/local/etc/php/conf.d/xdebug.ini && ./doc/docker/install_script.sh"
+    command: sh -c "rm -f /usr/local/etc/php/conf.d/xdebug.ini && ./doc/docker/install_script.sh"


### PR DESCRIPTION
Currently install-dependencies.ym use the php dev image which has xdebug installed and makes installing deps really slow.