### PR TITLE
[Docker] Added DATABASE_VERSION variable to install-dependencies

### DIFF
--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -12,6 +12,7 @@ services:
      - APP_ENV=${APP_ENV-prod}
      - APP_DEBUG
      - APP_CMD
+     - DATABASE_VERSION
      - DATABASE_USER
      - DATABASE_PASSWORD
      - DATABASE_NAME


### PR DESCRIPTION
Detected when working on: https://github.com/ezsystems/docker-php/pull/52 , which uses the `doc/docker/install-dependencies.yml -f doc/docker/install-database.yml` Dockerfiles.

Looks like the `DATABASE_VERSION` variable is not passed to the install_dependencies container, resulting in:
```
install_dependencies_1  | 
install_dependencies_1  | Checking database is up, attempt: 1
install_dependencies_1  | Ok: Connection succeeded to mysql 'ezp'.
install_dependencies_1  | > @php bin/console ezplatform:install clean
install_dependencies_1  | Creating database ezp if it does not exist, using doctrine:database:create --if-not-exists
install_dependencies_1  | 
install_dependencies_1  | In DBALException.php line 81:
install_dependencies_1  |                                                                                
install_dependencies_1  |   Invalid platform version "" specified. The platform version has to be speci  
install_dependencies_1  |   fied in the format: "<major_version>.<minor_version>.<patch_version>".      
```
when `docker-compose -f doc/docker/install-dependencies.yml -f doc/docker/install-database.yml up --abort-on-container-exit` is run.

The error is coming from this line: https://github.com/ezsystems/ezplatform/blob/3.0/doc/docker/install_script.sh#L16
and the DATABASE_VERSION variable has been added in this PR: https://github.com/ezsystems/ezplatform/pull/576/files