### PR TITLE
[Docker] Removed hardcoded -node and -dev image usages

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.4-v1
+PHP_IMAGE=ezsystems/php:7.4-v1-node
 PHP_IMAGE_DEV=ezsystems/php:7.4-v1-dev
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb

--- a/doc/docker/Dockerfile-app
+++ b/doc/docker/Dockerfile-app
@@ -1,5 +1,5 @@
 ARG PHP_IMAGE=ezsystems/php:7.4-v1
-FROM ${PHP_IMAGE}-node as builder
+FROM ${PHP_IMAGE} as builder
 
 # This is prod image (for dev use just mount your application as host volume into php image we extend here)
 ENV SYMFONY_ENV=prod

--- a/doc/docker/Dockerfile-distribution
+++ b/doc/docker/Dockerfile-distribution
@@ -4,7 +4,7 @@ ARG DISTRIBUTION_IMAGE=docker_app
 ARG PHP_IMAGE=ezsystems/php:7.4-v1
 FROM ${DISTRIBUTION_IMAGE} as distrofiles
 
-FROM ${PHP_IMAGE}-node as builder
+FROM ${PHP_IMAGE} as builder
 
 COPY --from=distrofiles /var/www /var/www
 

--- a/doc/docker/Dockerfile-nginx
+++ b/doc/docker/Dockerfile-nginx
@@ -1,5 +1,5 @@
 ARG PHP_IMAGE=ezsystems/php:7.4-v1
-FROM ${PHP_IMAGE}-node as web-build
+FROM ${PHP_IMAGE} as web-build
 
 ENV SYMFONY_ENV=prod
 

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -3,7 +3,7 @@ version: '3.3'
 
 services:
   app:
-    image: ${PHP_IMAGE}-node
+    image: ${PHP_IMAGE}
     volumes:
      - ${COMPOSE_DIR}/../../:/var/www:cached
      - ${COMPOSER_HOME}:/root/.composer:cached

--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -3,7 +3,7 @@ version: '3.3'
 
 services:
   install_dependencies:
-    image: ${PHP_IMAGE}-dev
+    image: ${PHP_IMAGE_DEV}
     volumes:
      - ${COMPOSE_DIR}/../..:/var/www:cached
      - ${COMPOSER_HOME}:/root/.composer:cached


### PR DESCRIPTION
Removing the hardcoded `-node` and `-dev` variants to that our builds will keep working after https://github.com/ezsystems/docker-php/pull/52 is merged (and the build in https://github.com/ezsystems/docker-php/pull/52 can pass)

Once the above PR is merged I'll prepare another PR to this repo to switch to Docker v2 images.