### PR TITLE
[Travis] Specified PHP_IMAGE_DEV for 7.1 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
       env:
         - BEHAT_OPTS="--profile=adminui --suite=adminui"
         - PHP_IMAGE=ezsystems/php:7.1-v1-node
+        - PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
 
 # reduce depth (history) of git checkout
 git:


### PR DESCRIPTION
Failing build: https://travis-ci.org/github/ezsystems/ezplatform/jobs/714344080 after https://github.com/ezsystems/ezplatform/pull/588

Needs to be adapted for 3.0, 3.1 and master to `ezsystems/php:7.3-v1-dev`