### PR TITLE
[Docker] Switched image format and added PostgreSQL service

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,7 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.4-v1-node
-PHP_IMAGE_DEV=ezsystems/php:7.4-v1-dev
+PHP_IMAGE=ezsystems/php:7.3-v2-node10
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
 SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-20200326

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,11 +59,11 @@ matrix:
         - SETUP_BEHAT_OPTS="--profile=setup --suite=personas --tags=@setup"
         - BEHAT_OPTS="--profile=adminui --suite=personas"
     - if: type in (cron, api)
-      name: "[PHP 7.1] Admin UI on Clean Platform"
+      name: "[PHP 7.1/PostgreSQL] Admin UI on Clean Platform"
       env:
+        - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/selenium.yml"
         - BEHAT_OPTS="--profile=adminui --suite=adminui"
-        - PHP_IMAGE=ezsystems/php:7.1-v1-node
-        - PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
+        - PHP_IMAGE=ezsystems/php:7.1-v2-node10
 
 # reduce depth (history) of git checkout
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - SYMFONY_ENV=behat
     - SYMFONY_DEBUG=1
+    - PHP_IMAGE=ezsystems/php:7.4-v2-node10
 
 cache:
   yarn: true

--- a/doc/docker/README.md
+++ b/doc/docker/README.md
@@ -43,6 +43,7 @@ The current Docker Compose files are made to be mixed and matched together for Q
 - redis-session.yml _(optional, stores sessions in a separate redis instance)_
 - varnish.yml _(optional, adds varnish service and appends config to app)_
 - solr.yml _(optional, add solr service and configure app for it)_
+- db-postgresql.yml _(optional, switches the DB engine to PostgreSQL - experimental)_
 - selenium.yml _(optional, always needs to be last, adds selenium service and appends config to app)_
 - multihost.yml _(optional, adds multihost config to app container network)_
 

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -11,6 +11,7 @@ services:
      - db
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - ENABLE_XDEBUG
      - EZPLATFORM_SITEACCESS
      - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-dev}
@@ -25,6 +26,7 @@ services:
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
      - HTTPCACHE_VARNISH_INVALIDATE_TOKEN
+     - XDEBUG_CONFIG
     networks:
      - backend
 

--- a/doc/docker/db-postgresql.yml
+++ b/doc/docker/db-postgresql.yml
@@ -1,0 +1,22 @@
+version: '3.3'
+# Single server setup for dev
+
+services:
+  app:
+    environment:
+     - DATABASE_PORT=5432
+     - DATABASE_DRIVER=pdo_pgsql
+     - DATABASE_PLATFORM=pgsql
+     - DATABASE_CHARSET=utf8
+     - DATABASE_VERSION=9.4
+
+  db:
+    image: postgres:9.4
+    environment:
+      - POSTGRES_USER=$DATABASE_USER
+      - POSTGRES_PASSWORD=$DATABASE_PASSWORD
+      - POSTGRES_DB=$DATABASE_NAME
+    networks:
+      - backend
+    ports:
+      - "5433:5432"

--- a/doc/docker/import-dataset.yml
+++ b/doc/docker/import-dataset.yml
@@ -13,8 +13,7 @@ services:
           nocopy: false
 
   import-db:
-    # Using dev for now, because we need mysql client
-    image: ${PHP_IMAGE_DEV}
+    image: ${PHP_IMAGE}
     environment:
      - DATABASE_USER
      - DATABASE_PASSWORD

--- a/doc/docker/install-dependencies.yml
+++ b/doc/docker/install-dependencies.yml
@@ -3,12 +3,13 @@ version: '3.3'
 
 services:
   install_dependencies:
-    image: ${PHP_IMAGE_DEV}
+    image: ${PHP_IMAGE}
     volumes:
      - ${COMPOSE_DIR}/../..:/var/www:cached
      - ${COMPOSER_HOME}:/root/.composer:cached
     environment:
      - COMPOSER_MEMORY_LIMIT
+     - PHP_INI_ENV_memory_limit
      - SYMFONY_ENV=${SYMFONY_ENV-prod}
      - SYMFONY_DEBUG
      - SYMFONY_CMD


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31620

This PR is the result of work done recently in docker-php, mostly https://github.com/ezsystems/docker-php/pull/52.

I have:
- switched the default PHP_IMAGE to `ezsystems/php:7.4-v2-node10` and dropped `PHP_IMAGE_DEV`, it's no longer used in our Docker stack
- added `ENABLE_XDEBUG` and `XDEBUG_CONFIG` variables to base-dev and base-prod (which should make  https://github.com/ezsystems/ezplatform/pull/587 not needed anymore - xdebug is present in all images now)
- added a new PostgreSQL Docker service
- added a job running Behat tests on PostgreSQL (requires https://github.com/ezsystems/ezplatform-admin-ui/pull/1445 to pass)

Passing PostgreSQL build: https://travis-ci.org/github/ezsystems/ezplatform/builds/715567661

