### PR TITLE
EZP-31804: [Docker] Added fixed IP to varnish container to workaround TRUSTED_PROXIES setting

### DIFF
--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -9,7 +9,9 @@ services:
   app:
     environment:
      - SYMFONY_HTTP_CACHE=0
-     - SYMFONY_TRUSTED_PROXIES=varnish
+     # Never do this in production if the app container is accesible for the public as well
+     # See https://ezplatform.com/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly for more details how it could be abused
+     - SYMFONY_TRUSTED_PROXIES=TRUST_REMOTE 
      - HTTPCACHE_PURGE_SERVER=http://varnish
      - HTTPCACHE_PURGE_TYPE=varnish
 

--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -11,7 +11,7 @@ services:
      - SYMFONY_HTTP_CACHE=0
      - SYMFONY_TRUSTED_PROXIES=varnish
      - HTTPCACHE_PURGE_SERVER=http://varnish
-     - HTTPCACHE_PURGE_TYPE=http
+     - HTTPCACHE_PURGE_TYPE=varnish
 
   varnish:
     build:


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31804

A potential replacement to the solution proposed in https://github.com/ezsystems/docker-php/pull/34

Currently we set `varnish` as trusted proxy, but it doesn't work - Symfony does not resolve hostnames when looking at trusted proxies, meaning that in our Docker stack no proxy is trusted. This makes it impossible to purge cache correctly when using it.

Things I've considered:
Currently `varnish` has a dependency on `app` (because it resolves the `app` hostname in `--acl-add` command, so adding a `varnish` dependency to `app` to resolve trusted proxy would create a circular dependency.

This leaves as with a possibility to wait until `varnish` container is available as in https://github.com/ezsystems/docker-php/pull/34 or we could try to set the IP without resolving hostname:
1) by setting varnish to "trust all" - I didn't want to do it as it's against best practices when `app` container is available to the public
2) by setting a fixed network range or fixed IP as trusted proxy - this solution makes the `backend` network (so the network used both by `varnish` and `app`) to use a specified subnet with Varnish container having a fixed IP in that subnet - so that we don't have to resolve it and can hardcode it.

This fixed subnet is specified only in `varnish.yml`, so there's no change for people not using it.
Also in our Docker stack there is only one varnish instance (and I don't think we have a plan to introduce multiple reverse proxies in front of our application in the Docker stack, Fastly-style) so IMHO having a fixed IP is acceptable here.

