### PR TITLE
services.yaml: solr:6.6 → Solr:7.7

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -57,7 +57,7 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:6.6
+#    type: solr:7.7
 #    disk: 512
 #    configuration:
 #        configsets:


### PR DESCRIPTION
Files created by generate-solr-config.sh don't work on Solr 6.6 image used by Platform.sh and cause “collection1: org.apache.solr.common.SolrException:org.apache.solr.common.SolrException: Missing required init param 'defaultFieldType'”

To use a Solr 7.7 image with the generated config works.

https://github.com/ezsystems/ezplatform-solr-search-engine/commit/da9056d5a31ff7d4ecb01690ed53b2981854e2b8