### PR TITLE
EZP-31740: Fixed and migrated DFS configuration to Symfony 5

### DIFF
--- a/config/packages/dfs/dfs.yaml
+++ b/config/packages/dfs/dfs.yaml
@@ -1,7 +1,8 @@
 parameters:
     env(DFS_DATABASE_URL): '%env(resolve:DATABASE_URL)%'
     ibexa.platform.io.nfs.adapter.config:
-        directory: '%dfs_nfs_path%/$var_dir$/$storage_dir$'
+        root: '%dfs_nfs_path%'
+        path: '$var_dir$/$storage_dir$/'
         writeFlags: ~
         linkHandling: ~
         permissions: [ ]

--- a/config/packages/dfs/dfs.yaml
+++ b/config/packages/dfs/dfs.yaml
@@ -1,22 +1,30 @@
+parameters:
+    env(DFS_DATABASE_URL): '%env(resolve:DATABASE_URL)%'
+    ibexa.platform.io.nfs.adapter.config:
+        directory: '%dfs_nfs_path%/$var_dir$/$storage_dir$'
+        writeFlags: ~
+        linkHandling: ~
+        permissions: [ ]
+
 # new doctrine connection for the dfs legacy_dfs_cluster metadata handler.
 doctrine:
     dbal:
         connections:
             dfs:
-                driver: "%dfs_database_driver%"
-                host: "%dfs_database_host%"
-                port: "%dfs_database_port%"
-                user: "%dfs_database_user%"
-                password: "%dfs_database_password%"
-                dbname: "%dfs_database_name%"
-                charset: utf8mb4
+                # configure these for your database server
+                driver: '%dfs_database_driver%'
+                charset: '%dfs_database_charset%'
+                default_table_options:
+                    charset: '%dfs_database_charset%'
+                    collate: '%dfs_database_collation%'
+                url: '%env(resolve:DFS_DATABASE_URL)%'
 
 # define the flysystem handler
 oneup_flysystem:
     adapters:
         nfs_adapter:
-            local:
-                directory: "/%dfs_nfs_path%/$var_dir$/$storage_dir$"
+            custom:
+                service: ibexa.platform.io.nfs.adapter.site_access_aware
 
 # define the ez handlers
 ez_io:

--- a/config/packages/dfs/dfs.yaml
+++ b/config/packages/dfs/dfs.yaml
@@ -1,5 +1,6 @@
 parameters:
     env(DFS_DATABASE_URL): '%env(resolve:DATABASE_URL)%'
+    dfs_database_url: '%env(resolve:DFS_DATABASE_URL)%'
     ibexa.platform.io.nfs.adapter.config:
         root: '%dfs_nfs_path%'
         path: '$var_dir$/$storage_dir$/'
@@ -18,7 +19,7 @@ doctrine:
                 default_table_options:
                     charset: '%dfs_database_charset%'
                     collate: '%dfs_database_collation%'
-                url: '%env(resolve:DFS_DATABASE_URL)%'
+                url: '%dfs_database_url%'
 
 # define the flysystem handler
 oneup_flysystem:

--- a/config/packages/overrides/generic.php
+++ b/config/packages/overrides/generic.php
@@ -6,49 +6,27 @@
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader;
 
-require_once dirname(__DIR__, 2).'/bootstrap.php';
+require_once dirname(__DIR__, 2) . '/bootstrap.php';
 
-    if ($dfsNfsPath = $_SERVER['DFS_NFS_PATH'] ?? false) {
+/** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
+if ($dfsNfsPath = $_SERVER['DFS_NFS_PATH'] ?? false) {
     $container->setParameter('dfs_nfs_path', $dfsNfsPath);
 
-    if ($value = $_SERVER['DFS_DATABASE_DRIVER'] ?? false) {
-        $container->setParameter('dfs_database_driver', $value);
-    } else {
-        $container->setParameter('dfs_database_driver', $container->getParameter('database_driver'));
+    $parameterMap = [
+        'dfs_database_charset' => 'database_charset',
+        'dfs_database_driver' => 'database_driver',
+        'dfs_database_collation' => 'database_collation',
+    ];
+
+    foreach ($parameterMap as $dfsParameter => $platformParameter) {
+        $container->setParameter(
+            $dfsParameter,
+            $_SERVER[strtoupper($dfsParameter)] ?? $container->getParameter($platformParameter)
+        );
     }
 
-    if ($value = $_SERVER['DFS_DATABASE_HOST'] ?? false) {
-        $container->setParameter('dfs_database_host', $value);
-    } else {
-        $container->setParameter('dfs_database_host', $container->getParameter('database_host'));
-    }
-
-    if ($value = $_SERVER['DFS_DATABASE_PORT'] ?? false) {
-        $container->setParameter('dfs_database_port', $value);
-    } else {
-        $container->setParameter('dfs_database_port', $container->getParameter('database_port'));
-    }
-
-    if ($value = $_SERVER['DFS_DATABASE_NAME'] ?? false) {
-        $container->setParameter('dfs_database_name', $value);
-    } else {
-        $container->setParameter('dfs_database_name', $container->getParameter('database_name'));
-    }
-
-    if ($value = $_SERVER['DFS_DATABASE_USER'] ?? false) {
-        $container->setParameter('dfs_database_user', $value);
-    } else {
-        $container->setParameter('dfs_database_user', $container->getParameter('database_user'));
-    }
-
-    if ($value = $_SERVER['DFS_DATABASE_PASSWORD'] ?? false) {
-        $container->setParameter('dfs_database_password', $value);
-    } else {
-        $container->setParameter('dfs_database_password', $container->getParameter('database_password'));
-    }
-
-    $loader = new Loader\YamlFileLoader($container, new FileLocator(dirname(__DIR__).'/dfs'));
-    $loader->load('dfs.yml');
+    $loader = new Loader\YamlFileLoader($container, new FileLocator(dirname(__DIR__) . '/dfs'));
+    $loader->load('dfs.yaml');
 }
 
 // Cache settings


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31738](https://jira.ez.no/browse/EZP-31738), [EZP-31739](https://jira.ez.no/browse/EZP-31739), [EZP-31740](https://jira.ez.no/browse/EZP-31740).
| **Requires**                        | ezsystems/ezplatform-kernel#108
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`+
| **BC breaks**                          | yes
| **Doc needed**                       | yes

## TL;DR;

This PR fixes DFS configuration and adjusts it for Symfony 5 changes.

## Breaking changes

There's no way to fix configuration in a BC-safe way due to changes between Symfony 3 and 5.

Required configuration is as follows
```bash
DFS_DATABASE_URL=<dfs_db_url>
DFS_NFS_PATH=<absolute-nfs-path>
```
+ changes from this PR diff.

## Doc

It's no longer possible to use local NFS adapter shipped with Flysystem (3rd party). Developers who want dynamic (SiteAccess-dependent) paths in their NFS directory path need to use our new SiteAccess-aware adapter. Thus meta repository upgrade is required. Patch from this Pull Request can be applied on a project. Also it's worth to mention this in deprecation/removal section of 3.x doc and in upgrade instructions.

### Upgrade:

#### Env settings:
Before:
```
DFS_DATABASE_NAME=<dfs_db_name>
DFS_NFS_PATH=<absolute-nfs-path>
```

After:
```bash
DFS_DATABASE_URL=<dfs_db_url>
DFS_NFS_PATH=<absolute-nfs-path>
```

#### Project configuration (if the patch was applied and dfs.yaml hasn't been customized, then this step is not required):

Before:
```yaml
oneup_flysystem:
    adapters:
        nfs_adapter:
            local:
                directory: "/%dfs_nfs_path%/$var_dir$/$storage_dir$"
```

After:
```yaml
oneup_flysystem:
    adapters:
        nfs_adapter:
            custom:
                service: ibexa.platform.io.nfs.adapter.site_access_aware
```

### QA

Internal sync might be required before proceeding because the configuration is quite complicated.

This PR fixes multiple issues which cannot be reproduced separately, so DFS sanities are in order.

Multi-repository case can be set-up applying [this example](https://github.com/ezsystems/ezplatform/compare/master...alongosz:example-3.1/ezp-31740-multirepo-for-dfs) onto this PR's patch.

Please also check if default configuration (no DFS, stored locally in public directory) is still working.



