### PR TITLE
EZP-31930: Improved output of `composer ezplatform-install` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
         ],
         "ezplatform-install": [
-            "@php bin/console ezplatform:install clean"
+            "@php bin/console --ansi ezplatform:install clean"
         ]
     },
     "config": {


### PR DESCRIPTION
**JIRA**: [EZP-31930](https://jira.ez.no/browse/EZP-31930)
**Target version**: 2.5.x, 3.1.x, 3.2
---

This is yet another attempt like ezsystems/ezpublish-kernel#2593 to fix the output of `ezplatform:install` Symfony command piped through Composer (`composer ezplatform-install`).
The issue is visible e.g. [here](https://travis-ci.org/github/ezsystems/ezplatform/jobs/728930873#L1072-L1078) or locally.
![image](https://user-images.githubusercontent.com/7099219/93764715-e2ed4480-fc13-11ea-83d2-48fb20332352.png)

Seems it looks better when `bin/console` has `--ansi` option. TBD if this solves the issue for all platforms.

### QA
See **TODO** list.

### TODO
- [x] Create JIRA ticket if this works
- [x] Platforms: Linux hosted on Travis: [slightly better](https://travis-ci.org/github/ezsystems/ezplatform/jobs/728966991#L1028-L1036)
- [x] Platforms: Linux hosted locally: works very well locally on Ubuntu 20.04 (@alongosz).
- [ ] Platforms: Linux hosted VBox (TBD by QA)
- [ ] Platforms: MacOS: TBD
- [ ] Platforms: Windows: TBD