### PR TITLE
Fix cache_namespace parameters for memcached and filesystem cache

### DIFF
--- a/config/packages/cache_pool/cache.memcached.yaml
+++ b/config/packages/cache_pool/cache.memcached.yaml
@@ -3,7 +3,8 @@
 # For further reading on setup with eZ Platform and Memcached:
 # https://doc.ezplatform.com/en/latest/guide/persistence_cache/#memcached
 parameters:
-    cache_namespace: ezp
+    cache_namespace: '%env(CACHE_NAMESPACE)%'
+    cache_dsn: '%env(CACHE_DSN)%'
 
 services:
     cache.memcached:

--- a/config/packages/cache_pool/cache.tagaware.filesystem.yaml
+++ b/config/packages/cache_pool/cache.tagaware.filesystem.yaml
@@ -2,7 +2,7 @@
 #
 # Loaded by default, for use on single server setups.
 parameters:
-    cache_namespace: ezp
+    cache_namespace: '%env(CACHE_NAMESPACE)%'
 
 services:
     cache.tagaware.filesystem:


### PR DESCRIPTION
Fixes `cache_namespace` parameters to be in sync with Redis config.