### PR TITLE
Added conflict with doctrine/dbal >= 2.11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
         "ezsystems/behatbundle": "^6.5.8",
         "ezsystems/ezplatform-i18n": "^1.5@dev"
     },
+    "conflict": {
+        "doctrine/dbal": ">=2.11.0"
+    },
     "scripts": {
         "symfony-scripts": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",


### PR DESCRIPTION
> JIRA: -

#### Description

Added conflict with doctrine/dbal >= 2.11.0 to unblock CI on 1.13 branch:

```
install_app_1_1a889336cc0b | > Incenteev\ParameterHandler\ScriptHandler::buildParameters
install_app_1_1a889336cc0b | Creating the "app/config/parameters.yml" file
install_app_1_1a889336cc0b | > Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
install_app_1_1a889336cc0b | > eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::clearCache
install_app_1_1a889336cc0b | 
install_app_1_1a889336cc0b |                                                         
install_app_1_1a889336cc0b |   [Symfony\Component\Console\Exception\LogicException]  
install_app_1_1a889336cc0b |   An option named "connection" already exists.          
install_app_1_1a889336cc0b |                                                         
install_app_1_1a889336cc0b | 
install_app_1_1a889336cc0b | Script eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::clearCache handling the symfony-scripts event terminated with an exception
install_app_1_1a889336cc0b | 
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |   [RuntimeException]                                                         
install_app_1_1a889336cc0b |   An error occurred when executing the "'cache:clear --no-warmup'" command:  
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b |     [Symfony\Component\Console\Exception\LogicException]                     
install_app_1_1a889336cc0b |     An option named "connection" already exists.                             
install_app_1_1a889336cc0b |                                                                              
install_app_1_1a889336cc0b | 
install_app_1_1a889336cc0b | install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...
```

Source build: https://travis-ci.org/github/ezsystems/ezplatform/jobs/731802629

#### Links:

*   doctrine/DoctrineBundle#1168