### PR TITLE
vhost.template: Update default APP_ENV from prod to dev

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -45,7 +45,7 @@
 
     # Environment.
     # Possible values: "prod" and "dev" out-of-the-box, other values possible with proper configuration
-    # Defaults to "prod" if omitted (uses SetEnvIf so value can be used in rewrite rules)
+    # Defaults to "dev" if omitted (uses SetEnvIf so value can be used in rewrite rules)
     #if[APP_ENV] SetEnvIf Request_URI ".*" APP_ENV=%APP_ENV%
 
     # Optional: Whether to use debugging.

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -40,7 +40,7 @@ server {
             # Environment.
             # Possible values: "prod" and "dev" out-of-the-box, other values possible with proper configuration
             # Make sure to comment the "ez_params.d/ez_prod_rewrite_params" include above in dev.
-            # Defaults to "prod" if omitted
+            # Defaults to "dev" if omitted
             #if[APP_ENV] fastcgi_param APP_ENV %APP_ENV%;
 
             # Whether to use debugging.


### PR DESCRIPTION
Since eZ Platform 3 on Symfony 5, if `APP_ENV` is omitted from VHost, .env and .env.local, default environment is `dev`.

In https://github.com/ezsystems/ezplatform/blob/v3.1.3/config/bootstrap.php, when APP_ENV is undefined or null:
- if Dotenv is used, Dotenv will set APP_END to 'dev' in https://github.com/symfony/dotenv/blob/v5.1.6/Dotenv.php#L109 ;
- if Dotenv isn't used, the bootstrap will set it to dev at line 19.

Tested using Apache on
- eZ Platform EE 2.5.14 where default is prod;
- eZ Platform EE 3.1.3 where default is dev. 