### PR TITLE
EZP-31982: Revert cache setting in Encore config to default

### DIFF
--- a/config/packages/webpack_encore.yaml
+++ b/config/packages/webpack_encore.yaml
@@ -10,4 +10,4 @@ webpack_encore:
 
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
     # Available in version 1.2
-    cache: '%kernel.debug%'
+    # cache: true


### PR DESCRIPTION
JIRA: [EZP-31982](https://jira.ez.no/browse/EZP-31982)

This in practice disables Encore built-in cache on dev environments, following Symfony's default configuration in this matter.

Fixes an issue when adding new entrypoints to webpack.config.js that were not recognized until cache was cleared - which lead
to confusing errors occuring in template files that included those entrypoints.