### PR TITLE
Good Lando defaults

### DIFF
--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -1,0 +1,32 @@
+# This file sets some good defaults for local development using this Platform.sh
+# template with Lando.
+#
+# Note that you should not edit this file so it can continue to receive upstream
+# updates. If you wish to change the values below then override them in your
+# normal .lando.yml.
+
+# These both allow you to test this template without needing a site on Platform.sh
+# However you will want to replace them in your .lando.yml
+name: platformsh-ezplatform
+recipe: platformsh
+
+config:
+
+  # This section overrides Platform.sh configuration with values that make more
+  # sense for local development.
+  #
+  # Note that "app" is the name of the application defined in your
+  # .platform.app.yaml or applications.yaml.
+  overrides:
+    app:
+      variables:
+        env:
+          APP_ENV: dev
+          APP_DEBUG: 1
+
+# These are tools that are commonly used during development for this template.
+tooling:
+  console:
+    cmd: /app/bin/console
+    service: app
+

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -131,7 +131,11 @@ hooks:
             echo "See: https://docs.platform.sh/tutorials/composer-auth.html#set-the-envcomposerauth-project-variable"
         fi
 
-        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+        if [ $APP_ENV != "prod" ]; then
+            composer install
+        else
+            composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+        fi
 
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s


### PR DESCRIPTION
@lando is working closely with @platformsh to "Landoify" its application templates so:

* They contain good defaults and needed local overrides for the Platform.sh config
* They can all be stood up using Lando's Platform.sh integration with a simple `git clone && lando start`

Unlike the other Platform.sh application templates the eZ Platform one lives outside of the Platform.sh organization eg here. Not sure if this is the best way to submit the PR so please advise!
 
cc @Crell and @gauthiergarnier 