### PR TITLE
EZP-31821: Failing security-checker results in errored installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "@php bin/security-checker security:check"
+            "@php bin/security-checker security:check || true"
         ],
         "post-install-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-31821
For all supported branches.

There have been repeated requests for the security checker not to break the installation process. If we accept the premise that the checker should not lead to errors, but should still run and display packages with vulnerabilites, then this is a simple way to do it. This shows the output from `composer install && echo "SUCCESS!"` in v1.13 (and v2.5).

![v1 13 5](https://user-images.githubusercontent.com/289744/95440595-6cfa1480-0959-11eb-8ebe-1c882898caa4.png)

In v3.x Symfony scripts are run in a different way, and if we apply the same fix there it will not show the output from security-checker, just a green OK. If we're not going to fork the relevant Symfony repo, and if there's no easy way to overload it, then we have to go back to the old way of running security checker. And that requires moving it out from the `auto-scripts` section, [as is shown here](https://gist.github.com/glye/c1a8f4335bdca732f55eb3e08559503a). With that fix, there is no green OK, but it works the same way as in v2/v1.

![v3 1 1](https://user-images.githubusercontent.com/289744/95441408-661fd180-095a-11eb-8c26-2b5cfbda3591.png)

Yes, it's hackish, and the `|| true` is visible in the output. But it seems to be the simplest possible solution, and is easily reversible for those who may want to keep the old behaviour.