### PR TITLE
EZP-32017: fix trusted proxy setup for platform.sh

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,30 @@ if ($_SERVER['APP_DEBUG']) {
     Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+$trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? '';
+
+// specific for platform.sh deployed to both with and without varnish access, when you should not trust REMOTE_ADDR
+// platform sh is putting real client ip into REMOTE_ADDR instead of proxy IP, so we can't verify it
+// see https://github.com/symfony/symfony/issues/26006
+// but we can be sure that it's coming from varnish if REMOTE_ADDR is second from the end of 'x-forwarded-for'
+if (
+    isset($_SERVER['PLATFORM_PROJECT_ENTROPY'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_X_CLIENT_IP'])
+    && $_SERVER['HTTP_X_CLIENT_IP'] === $_SERVER['REMOTE_ADDR']
+) {
+    // array_unique to make sure user didn't send own IP in x-forwarded-for
+    // strtolower for ipv6 uniqueness
+    $reverseIps = array_unique(array_reverse(array_map(
+        'trim',
+        explode(',', strtolower($_SERVER['HTTP_X_FORWARDED_FOR']))
+    )));
+    if (isset($reverseIps[1]) && $reverseIps[1] === $_SERVER['REMOTE_ADDR']) {
+        // restore real remote addr, overrided by ngx_http_realip_module, and trust it
+        $trustedProxies = ($trustedProxies ? ',' : '') . $reverseIps[0];
+        $_SERVER['REMOTE_ADDR'] = $reverseIps[0];
+    }
+}
+
+if ($trustedProxies) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
 


### PR DESCRIPTION
platform.sh use "ngx_http_realip_module" nginx module, and put client IP into REMOTE_ADDR.
This makes it impossible to configure an application to be accessible from both with and without varnish. For example, serve a website by varnish and admin by Nginx.

If you'll put REMOTE_ADDR in TRUSTED_PROXIES, admin panel will be open to IP address spoof using "x-forwarded-for" header.
And, the user will be able to request your varnish invalidation token.

If you'll put other IP address, or don't specify TRUSTED_PROXIES at all, you'll receive "Unauthorized" from varnish (because of "/_ez_http_invalidatetoken" route checking "$request->isFromTrustedProxy()", which will return false).

Ideally, it should work in a way where the developer can safely use

$request->getClientIp()
I'm not sure if this issue is reproducible on the EZ platform cloud, but I assume it should be there too.

related to https://github.com/symfony/symfony/issues/26006