### PR TITLE
EZP-31821: Failing security-checker results in errored installation (1.13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "@php bin/security-checker security:check"
+            "@php bin/security-checker security:check || true"
         ],
         "post-install-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
Reopening previously approved https://github.com/ezsystems/ezplatform/pull/608 for QA, as it was merged too soon and reverted. See description and screenshot there.

This applies to 1.13 and 2.5.
For 3.1+ see https://github.com/ezsystems/ezplatform/pull/612