### PR TITLE
EZP-31821: Failing security-checker results in errored installation (3.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,14 +117,15 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
             "yarn install": "script",
-            "ezplatform:encore:compile": "symfony-cmd",
-            "security-checker security:check": "script"
+            "ezplatform:encore:compile": "symfony-cmd"
         },
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@php bin/security-checker security:check || true"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@php bin/security-checker security:check || true"
         ],
         "ezplatform-install": [
             "@php bin/console ezplatform:install clean",


### PR DESCRIPTION
Reopening previously approved https://github.com/ezsystems/ezplatform/pull/608 for QA, as it was merged too soon and reverted. See description and screenshot there.

This applies to 3.1+.
For 1.13 and 2.5 see https://github.com/ezsystems/ezplatform/pull/611