### PR TITLE
Set default mailer_host correctly on Platform.sh

### DIFF
--- a/app/config/env/platformsh.php
+++ b/app/config/env/platformsh.php
@@ -37,7 +37,7 @@ foreach ($relationships['database'] as $endpoint) {
 }
 
 // If mailer_host has default value, then set it to platform.sh' default instead
-if ($container->getParameter('mailer_host') === '127.0.0.1') {
+if ($container->resolveEnvPlaceholders($container->getParameter('mailer_host'), true) === '127.0.0.1') {
     $container->setParameter('mailer_host', getenv('PLATFORM_SMTP_HOST'));
 }
 


### PR DESCRIPTION
Before the container is build, call to `$container->getParameter` will not returned the resolved values, but instead values like `%env(MAILER_HOST)%`

With this fix, the `mailer_host` setting is actually set correct on Platform.sh