### PR TITLE
[Tests] EZP-32103: Adjusted Behat config to behave more like prod

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -30,12 +30,7 @@ default:
 
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
 
-        FriendsOfBehat\SymfonyExtension:
-            kernel:
-                path: src/Kernel.php
-                class: App\Kernel
-                environment: behat
-                debug: true
+        FriendsOfBehat\SymfonyExtension: ~
 
         EzSystems\BehatBundle\BehatExtension: ~
 

--- a/config/packages/behat/doctrine.yaml
+++ b/config/packages/behat/doctrine.yaml
@@ -1,0 +1,32 @@
+doctrine:
+    orm:
+        auto_generate_proxy_classes: false
+        metadata_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        query_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        result_cache_driver:
+            type: service
+            id: doctrine.result_cache_provider
+
+services:
+    doctrine.result_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.result_cache_pool'
+    doctrine.system_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.system_cache_pool'
+
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system

--- a/config/packages/behat/ezplatform.yaml
+++ b/config/packages/behat/ezplatform.yaml
@@ -1,22 +1,6 @@
-# Siteaccesses are first added in ../ezplatform.yaml.
-# Only merge additional siteaccesses here.
-
-ezplatform:
-    siteaccess:
-        list:
-            - other_site
-        groups:
-            site_group:
-                - other_site
-        default_siteaccess: site
-        match:
-            URIElement: 1
 ezdesign:
     phpstorm:
         enabled: false
-
-ez_platform_standard_design:
-    override_kernel_templates: false
 
 parameters:
     ezsettings.admin_group.notifications.success.timeout: 20000

--- a/config/packages/behat/framework.yaml
+++ b/config/packages/behat/framework.yaml
@@ -1,2 +1,0 @@
-framework:
-    test: true

--- a/config/packages/behat/routing.yaml
+++ b/config/packages/behat/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: true


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/EZP-32103

~~Contains https://github.com/ezsystems/ezplatform/pull/623 and temp changes, needs rebase before merging.~~

Things done:
1) I've removed the default config from FriendsOfBehat\SymfonyExtension

We're using the default values for the kernel class and path. The env and debug value is taken from the loaded bootstrap file, which loads environmental variables - there's no change in behaviour if APP_ENV=behat, APP_DEBUG=1 is specified (which we do in all our builds) and it's not harcoded there in case someone wants to change it.

2) I've adjusted `behat` env configuration to be more prod-like: right now it contains all the files from `prod` env, reasoning: our tests should be running in a similar env as the production one (but with Debug enabled, so that errors are not silenced). I've also enabled strict_requirements for routing: https://symfony.com/doc/current/reference/configuration/framework.html#strict-requirements to make sure we're not silencing any errors. I had to do it because HTTP cache behaves in a weird way when `framework.test` setting is enabled - IMHO it's a good opportunity to decide how the `behat` env should behave.