### PR TITLE
[Docker] EZP-32103: Added app container to varnish debuggers 

### DIFF
--- a/doc/docker/entrypoint/varnish/parameters.vcl
+++ b/doc/docker/entrypoint/varnish/parameters.vcl
@@ -15,4 +15,5 @@ acl invalidators {
 acl debuggers {
     "127.0.0.1";
     "172.16.0.0"/20;
+// DEBUGGER
 }

--- a/doc/docker/varnish.yml
+++ b/doc/docker/varnish.yml
@@ -29,7 +29,7 @@ services:
     networks:
      - frontend
      - backend
-    command: ["--acl-add", "app"]
+    command: ["--acl-add", "app", "--debug-acl-add", "app"]
 
 ## DEBUG??
 # In need of debugging all request going to Varnish, use varnishlog, example:


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/EZP-32103

Added the possibility to add entries to the debuggers list in the Varnish VCL and added the `app` container to the list.
This is needed by https://github.com/ezsystems/ezplatform-http-cache/pull/138 , where I want to rely on the X-Cache: MISS/HIT header for tests.