### PR TITLE
EZP-31594: Replaced bin/console with original file from symfony/console recipe

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,18 +1,22 @@
 #!/usr/bin/env php
 <?php
+
 use App\Kernel;
-use eZ\Bundle\EzPublishCoreBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 
-if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;
+if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
 }
+
 set_time_limit(0);
+
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (!class_exists(Application::class)) {
-    throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
 }
 
 $input = new ArgvInput();
@@ -24,10 +28,11 @@ if ($input->hasParameterOption('--no-debug', true)) {
     putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-require dirname(__DIR__).'/config/bootstrap.php';
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
+
     if (class_exists(Debug::class)) {
         Debug::enable();
     }


### PR DESCRIPTION
> JIRA: https://issues.ibexa.co/browse/EZP-31594

This is complementary PR to https://github.com/ezsystems/ezplatform-kernel/pull/145 which removes custom `Application` class handling `--siteaccess` option. It's no longer needed because the option is now handled by CompilerPass and EventListener.