### PR TITLE
EZP-32242: Improve default platform.sh config for common usecases

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -37,9 +37,24 @@ relationships:
 
 variables:
     php:
-        # Example of setting php.ini config
+        # Some recommended defaults for php.ini settings, adapt for your project
         #"display_errors": "On"
         memory_limit: 512M
+        post_max_size: 256M
+        upload_max_filesize: 256M
+
+        # Tweaking some default config
+        opcache.memory_consumption: 256
+        opcache.max_accelerated_files: 20000
+        opcache.max_wasted_percentage: 10
+        opcache.revalidate_freq: 20
+        realpath_cache_ttl: 600
+
+        # https://docs.platform.sh/configuration/app/timezone.html#setting-an-application-runtime-timezone
+        date.timezone: Europe/Oslo
+
+        # Set session lifetime to 18h
+        session.gc_maxlifetime: 64800
     env:
         # We disable Symfony Proxy (AppCache), as we rather use Varnish
         SYMFONY_HTTP_CACHE: 0
@@ -66,6 +81,12 @@ web:
                 # Disable .php(3) and other executable extensions in the var directory
                 '^/var/.*(?i)\.(php3?|phar|phtml|sh|exe|pl|bin)$':
                     allow: false
+                # Asset expiry, to set it higher you'll need "cache busting", i.e. by versioning assets (see info in webpack.config.js)
+                # Note: For Fastly comment out "expires" line, and uncomment the two lines for Surrogate-Control header instead!
+                '^\/(assets|bundles)\/([^\/]+\/)?([^\/]+\/)?.*\.(jpe?g|png|gif|svgz?|css|js|json|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    expires: 1h
+                    #headers:
+                        #Surrogate-Control: max-age=3600
 
 # The size of the persistent disk of the application (in MB).
 disk: 3072
@@ -124,6 +145,9 @@ hooks:
         # Generic cleanup to remove files we don't want to be deployed to prod (you don't need this for "dev" ENV)
         rm web/app_dev.php
 
+        # Install platform.sh cli for cron use: backup (needs auth tokens) and re-deploy (for cert renew)
+        curl -sS https://platform.sh/cli/installer | php
+
     # Deploy hook, access to services & done once (per cluster, not per node), only mounts are writable at this point
     # Note: Http traffic is paused while this is running, so for prod code this should finish as fast as possible, < 30s
     deploy: |
@@ -147,6 +171,8 @@ hooks:
         # If you also need to clear Redis cache on every deploy, you can either use this command or redis-cli
         # Normally this should only be needed if cached data structures changes (upgrades), or you change data via sql (e.g. restore backup)
         ##php bin/console cache:pool:clear cache.redis
+        # Command above will just clear current pool/namespace set for default siteaccess, to clear all:
+        ##redis-cli -h rediscache.internal -p 6379 FLUSHALL
 
         # Example of additional deploy hooks if you use doctrine and/or kaliop migration bundle
         ##php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
@@ -161,7 +187,7 @@ hooks:
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
         ##bin/console fos:httpcache:invalidate:tag ez-all
-        # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
+        # Depending on your VCL, by default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
         ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
@@ -186,6 +212,13 @@ crons:
     weekly:
         spec: "0 0 * * 0"
         cmd: "php bin/console ezplatform:check-urls --quiet"
+    renewcert:
+        # Force a redeploy at 2 am (UTC) on the 5th and 20th of every month to renew certificates.
+        spec: '0 2 5,20 * *'
+        cmd: |
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                platform redeploy --yes --no-wait
+            fi
 
 runtime:
     extensions:

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -2,8 +2,11 @@
     type: upstream
     upstream: "varnish:http"
     cache:
-        # As this does not support Vary, and purging, we can't use this as Sf Proxy drop in.
-        # However it is possible to enable this for anonymous traffic when backend sends expiry headers.
+        # This cache does not support Tagging, purging, and user context hash, we can't use this for HttpCache.
+        # Instead use one of:
+        # - Varnish (default)
+        # - Fastly (needed on Enterprise Dedicated)
+        # - Symfony Proxy (AppCache, only for single server, limited performance and ESI support)
         enabled: false
 
 "https://www.{default}/":

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -27,7 +27,7 @@ mysqldb:
 
 # For use by Symfony Cache (used by eZ Platform SPI Persistence Cache)
 rediscache:
-    type: 'redis:5.0'
+    type: 'redis:6.0'
     # For cache you might need to increase the size of your plan if your installation has a sizeable amount of content.
     # Check with platform.sh staff if in doubt on this, and if it would make sense to configure larger redis size here.
     # size: L
@@ -35,7 +35,7 @@ rediscache:
         # For cache eZ Platform 2.5+ RedisTagAwareAdapter requries one of the 'volatile-*' eviction policies
         # https://docs.platform.sh/configuration/services/redis.html#eviction-policy
         # https://doc.ezplatform.com/en/2.5/getting_started/requirements/
-        maxmemory_policy: volatile-lru
+        maxmemory_policy: volatile-lfu
 
 # If you wish to have a separate Redis instance for sessions, uncomment
 # this service and the corresponding relationship in .platform.app.yaml.

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -32,7 +32,7 @@ doctrine:
                 server_version: '%database_version%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
-        naming_strategy: doctrine.orm.naming_strategy.underscore
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
 
 # If you are not using MySQL, you can comment-out this section

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -25,13 +25,14 @@ monolog:
     handlers:
         main:
             type: fingers_crossed
-            # eZ Platform sets this to critical instead of error to avoid too verbose logs in prod
-            action_level: critical
+            action_level: error
             handler: nested
         nested:
             type: '%log_type%'
             path: '%log_path%'
-            level: debug
+            level: error
+            include_stacktraces: '%log_stacktraces%'
+            max_files: '%log_max_files%'
         console:
             type: console
             process_psr_3_messages: false

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -102,7 +102,9 @@ parameters:
 
     ## Log type is one of "stream", "error_log" or other types supported by monolog
     # env: LOG_TYPE
-    log_type: stream
+    log_type: rotating_file
+    log_max_files: 10
+    log_stacktraces: true
 
     ## Mail transport used by SwiftMailer
     # env: MAILER_TRANSPORT

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,10 @@ Encore.setOutputPath('web/assets/build')
     .setPublicPath('/assets/build')
     .enableSassLoader()
     .enableReactPreset()
+    // If you can ensure all assets are versioned, you may cache assets longer. In such case it's important that you cache assets
+    // longer then the cached dynamic pages referring to them (i.e. cache_ttl: 1d, then 2d for assets to account for stale cache)
+    //.enableVersioning()
+    //.cleanupOutputBeforeBuild()
     .enableSingleRuntimeChunk();
 
 // Put your config here.


### PR DESCRIPTION
Includes:
- PHP ini tweaks for performance and higher default upload limit
- Log rotation to make sure log does not consume gigabytes of disk space
- Asset caching
- Monthly HTTPS cert renewable in cron before it expires
- Redis config tweaks
- smaller tweaks to inline doc

Log rotation is done by tweaking monolog settings, so this will also benefit non p.sh setups (incl local).

Todo on merge up:
- ~For 3.x add PHP preloading config~ _(will need to start to use separate build dir for that as server starts before deploy hook runs so as long as this is in a mount it is out of date or missing prior to deploy hook runs and clears cache)_