### PR TITLE
Removed obsolete configuration of translation

### DIFF
--- a/config/packages/ezplatform_admin_ui.yaml
+++ b/config/packages/ezplatform_admin_ui.yaml
@@ -28,14 +28,3 @@ ezplatform:
                 icon_sets:
                     default_icons: /bundles/ezplatformadminui/img/ez-icons.svg
                 default_icon_set: default_icons
-
-jms_translation:
-    configs:
-        admin:
-            dirs:
-                - '%kernel.project_dir%/vendor/ezsystems/ezplatform-admin-ui/src'
-            output_dir: '%kernel.project_dir%/vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/'
-            excluded_dirs: [Behat, Tests, node_modules]
-            extractor:
-                - ez_policy
-            output_format: "xliff"


### PR DESCRIPTION
This configuration is obsolete. The correct one is in `\EzSystems\EzPlatformAdminUiBundle\DependencyInjection\EzPlatformAdminUiExtension::prependJMSTranslation`