### PR TITLE
[Travis] Added logging into Docker Hub

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -81,6 +81,11 @@ if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
 
 fi
 
+if [[ -n "${DOCKER_PASSWORD}" ]]; then
+    echo "> Set up Docker credentials"
+    echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+fi
+
 echo "> Install DB and dependencies"
 docker-compose -f doc/docker/install-dependencies.yml up --abort-on-container-exit
 


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/EZP-32270

### Introduction 

Docker Hub introduces rate limiting when downloading images. From https://www.docker.com/blog/docker-hub-image-retention-policy-delayed-and-subscription-updates/ :
```
 Anonymous free users will be limited to 100 pulls per six hours, and authenticated free users will be limited to 200 pulls per six hours. 
```

This makes our build fail from time to time with:
```
(selenium/standalone-chrome-debug:3.141.59-20200326)...
3.141.59-20200326: Pulling from selenium/standalone-chrome-debug
stable: Pulling from library/nginx
ERROR: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```
(from https://travis-ci.com/github/ezsystems/ezplatform-http-cache/jobs/469283098 )

Travis also has a blogpost about it: https://blog.travis-ci.com/docker-rate-limits
with the key line being `Travis CI has a built in registry cache for Docker builds `.

I've received confirmation from Travis support that the registry cache is active only when we're authenticated to Docker:
```
Our Registry is designed to work as follows:

* Following Docker's rate limiting of anonymous pulls, we require builds to authenticate to Docker to ensure a consistent result of successful pulls unaffected by rate limits.
* After a successful, authenticated pull from Docker, new builds can take advantage of the Travis Registry for new builds.
* We recommend running builds while authenticated to avoid issues that may arise die to lack of authentication.
```

This comes with an obvious downside - env variables are not available when PRs are made from forks, which means PRs from forks won't be using the Travis registry cache and might encounter Docker hub rate limiting.
There are two solutions to that:
1) make our Docker Hub credentials public - not a good idea as they could be abused
2) explore caching images using Travis build cache - also not an elegant solution, at least in the ways I've explored it

This PR aims to solve the issue for our internal use, I think we can spend more time later to think about the best solution that takes our contributors into account (one of the above or something else completely).

What also needs to be done, if this is accepted: configure the DOCKER_USERNAME and DOCKER_PASSWORD variables for each repository.

### Results

Build passing without Docker credentials configured:
https://travis-ci.com/github/ezsystems/ezplatform/builds/212349699

Build passing with Docker credentials configured:
https://travis-ci.com/github/ezsystems/ezplatform/jobs/469590356
