### PR TITLE
EZP-32289: Remove obsoleted security-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "sensio/distribution-bundle": "^3.0.36 | ^4.0.42 | ^5.0.25",
         "sensio/framework-extra-bundle": "^3.0.29",
         "sensio/generator-bundle": "^2.5.3 | ^3.1.7",
-        "sensiolabs/security-checker": "^5.0.3",
         "symfony/assetic-bundle": "~2.8.2",
         "symfony/monolog-bundle": "^3.3.1",
         "symfony/swiftmailer-bundle": "^2.6.7 | ^3.2.4",
@@ -73,8 +72,7 @@
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "@php bin/security-checker security:check || true"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],
         "post-install-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
For: 1.13, 2.5, 3.1, 3.2
https://issues.ibexa.co/browse/EZP-32289

Sensiolabs security-checker will stop working at the end of January 2021. https://github.com/sensiolabs/security-checker

There are ways of keeping the functionality, but they will need testing to avoid the issue of reports breaking installations, which we fixed earlier in the current solution. So for now we can remove it, and add the new variant later.