### PR TITLE
[Travis] Created the local dependency directory on host for Composer command to pass

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -70,8 +70,12 @@ if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
     cd -
 
     # use local checkout path relative to docker volume
+    # create the directory for non-container commands to pass
+    if [ ! -d /var/www/${BASE_PACKAGE_NAME} ]; then
+        sudo mkdir -p /var/www/${BASE_PACKAGE_NAME}
+    fi
     echo "> Make composer use tested dependency local checkout ${TMP_TRAVIS_BRANCH} of ${BASE_PACKAGE_NAME}"
-    composer config repositories.localDependency git /var/www/${BASE_PACKAGE_NAME}
+    composer config repositories.localDependency path /var/www/${BASE_PACKAGE_NAME}
 
     echo "> Require ${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"
     if ! composer require --no-update "${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"; then


### PR DESCRIPTION
We have builds failing with errors like:
```
Switched to a new branch 'tmp_76f9e4b'
/home/travis/build/ezplatform
> Make composer use tested dependency local checkout tmp_76f9e4b of ezplatform-workflow
> Require ezsystems/ezplatform-workflow:dev-tmp_76f9e4b as 1.1.x-dev
  [RuntimeException]                                                           
  Failed to read package information from /var/www/ezplatform-workflow as the  
   path does not exist   
```

Link: https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/218066131

Root cause:
The issue is caused by these lines: https://github.com/ezsystems/ezplatform/blob/master/bin/.travis/trusty/setup_ezplatform.sh#L56-L80

We move the directory containg tested package to another location:
Code:
```
    # move dependency to directory available for docker volume
    BASE_PACKAGE_NAME=`basename ${DEPENDENCY_PACKAGE_NAME}`
    echo "> Move ${DEPENDENCY_PACKAGE_DIR} to ${EZPLATFORM_BUILD_DIR}/${BASE_PACKAGE_NAME}"
    mv ${DEPENDENCY_PACKAGE_DIR} ${EZPLATFORM_BUILD_DIR}/${BASE_PACKAGE_NAME}
    cd ${EZPLATFORM_BUILD_DIR}/${BASE_PACKAGE_NAME}
```
Output:
```
> Move /home/travis/build/ezsystems/ezplatform-workflow to /home/travis/build/ezplatform/ezplatform-workflow
```

And then try to configure Composer to use that dependency:
```
    # use local checkout path relative to docker volume
    echo "> Make composer use tested dependency local checkout ${TMP_TRAVIS_BRANCH} of ${BASE_PACKAGE_NAME}"
    composer config repositories.localDependency git /var/www/${BASE_PACKAGE_NAME}

    echo "> Require ${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"
    if ! composer require --no-update "${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"; then
        echo 'Failed requiring dependency' >&2
        exit 3
    fi
```

Please note the comment: `local checkout path relative to docker volume`. We've moved the dependency to `/home/travis/build/ezplatform/ezplatform-workflow`, but tell Composer to look for it in `/var/www/${BASE_PACKAGE_NAME}`.

Our Docker containers have the following volumes specified: https://github.com/ezsystems/ezplatform/blob/master/doc/docker/base-dev.yml#L8 (and `${COMPOSE_DIR}` evaluates to `/home/travis/build/ezplatform/`, meaning that `/home/travis/build/ezplatform/ezplatform-workflow` from host is mapped to `/var/www/ezplatform-workflow` inside Docker container.

But the next lines:
```
    if ! composer require --no-update "${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"; then
        echo 'Failed requiring dependency' >&2
        exit 3
    fi
```
So far, we have set Composer up to use a repository which does not exist on host (this is what the error message is saying to us:
```
  Failed to read package information from /var/www/ezplatform-workflow as the  
   path does not exist   
```
), it exists only in Docker container.

But the `composer require --no-update "${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}` is not invoked in the container, it is run on the host.

Before Composer 2.0.10 it did not make a difference - most likely because `--no-update` is used Composer did not care that one of the repositories points to a non-existant directory.

On Composer 2.0.10 the behaviour changed - Composer validates the repositories and complains that one of them has invalid configuration.

Solutions I've considered:
- Remake the setup script so that the require call for local dependency happens inside the Docker container. It's not that easy, as the container do not exist yet at that moment in script. When the install_dependencies container is run (https://github.com/ezsystems/ezplatform/blob/master/doc/docker/install-dependencies.yml) it invokes the install script:
https://github.com/ezsystems/ezplatform/blob/master/doc/docker/install_script.sh , which start from `composer install`. We would have to remake that script somehow to pass the dependency to require before it's called, which IMHO is not worth it - the script is no longer used for 3.3, the approach is changed for Flex setup.
- (this PR) Make sure the directory exists for local calls. Composer does not complain about the missing directory (because it exists) and everything works as it used to for calls made in Docker containers.

Also changed the repository type - `path` is the correct one when Composer should use local dependencies:
https://getcomposer.org/doc/05-repositories.md#path

Companion PR to test the solution:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1712
