### PR TITLE
[Travis] Disabled symlinking of local dependency

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -75,7 +75,10 @@ if [[ -n "${DEPENDENCY_PACKAGE_NAME}" ]]; then
         sudo mkdir -p /var/www/${BASE_PACKAGE_NAME}
     fi
     echo "> Make composer use tested dependency local checkout ${TMP_TRAVIS_BRANCH} of ${BASE_PACKAGE_NAME}"
-    composer config repositories.localDependency path /var/www/${BASE_PACKAGE_NAME}
+    REPOSITORY_PROPERTIES=$( jq -n \
+                  --arg basePackageName "/var/www/$BASE_PACKAGE_NAME" \
+                  '{"type": "path", "url": $basePackageName, "options": { "symlink": false }}' )
+    composer config repositories.localDependency "$REPOSITORY_PROPERTIES"
 
     echo "> Require ${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"
     if ! composer require --no-update "${DEPENDENCY_PACKAGE_NAME}:dev-${TMP_TRAVIS_BRANCH} as ${BRANCH_ALIAS}"; then


### PR DESCRIPTION
Example failure:
https://travis-ci.com/github/ezsystems/ezplatform-http-cache/jobs/486034188

Error:
```
 ---> ec18ce700090

Step 6/10 : COPY vendor/ezsystems/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl /etc/varnish/default.vcl

Service 'varnish' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder696197820/var/www/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl: no such file or directory
```
Varnish container fails to builds, because it's not able to find the `vendor/ezsystems/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl` file.

This happens only for builds in ezplatform-http-cache repository and is caused by https://github.com/ezsystems/ezplatform/pull/648 .

In https://github.com/ezsystems/ezplatform/pull/648 I've changed the repository type to `path`. This has one unforseen consequence - packages downloaded using that method are symlinked by default (Ref: https://getcomposer.org/doc/05-repositories.md#path)

The PR dependency is moved on the host to `/home/travis/build/ezplatform/ezplatform-http-cache` and there is no ezsystems/ezplatform-http-cache in the `vendor` directory - there is only a symlink to the actual location.
Looks like Docker is unable to resolve (follow) the symlink when trying to copy the file and reports that the file does not exists.

This solution disables symliniking of the dependency -it's mirrored (copied) instead, so that the files are where they are supposed to be and everything works as before.

I've tested the solution on 3.2 with 2 PRs:
https://github.com/ezsystems/ezplatform/pull/649
https://github.com/ezsystems/ezplatform-http-cache/pull/145
And Varnish container is setup correctly.