### PR TITLE
[Composer] Added symfony/flex 1.13 to conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
     "conflict": {
         "doctrine/persistence": "1.3.2",
         "symfony/framework-bundle": "5.1.0",
-        "symfony/symfony": "*"
+        "symfony/symfony": "*",
+        "symfony/flex": "1.13"
     },
     "replace": {
         "paragonie/random_compat": "2.*",


### PR DESCRIPTION
Running `composer create-project ezsystems/ezplatform:~3.2.0@dev` fails with:
```
Symfony operations: 1 recipe (eda21953ca18a1afdfbe9e87fd626866)
  - Configuring symfony/flex (>=1.0): From github.com/symfony/recipes:master


  [ErrorException]
  file_get_contents(/Users/mareknocon/Desktop/repos/flex_regression/qwe/vendor/babdev/pagerfanta-bundle/composer.json): failed to open stream: No such file or directory
```

which is caused by symfony/flex 1.13:
https://github.com/symfony/flex/issues/768

Limiting the version to 1.12.2 temporary prevents us from this issue.

2.5 is not affected: https://travis-ci.com/github/ezsystems/ezplatform/builds/226198968