### PR TITLE
[Composer] Added conflict with laminas/laminas-code:4.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,11 +81,12 @@
         "symfony/phpunit-bridge": "^3.4.18"
     },
     "conflict": {
-        "symfony/symfony": "3.4.9||3.4.12||3.4.16",
         "doctrine/dbal": "2.7.0",
         "doctrine/persistence": "1.3.2",
-        "twig/twig": "2.6.1",
-        "symfony/webpack-encore-bundle": "1.2.0||1.2.1"
+        "laminas/laminas-code": "4.4.0",
+        "symfony/symfony": "3.4.9||3.4.12||3.4.16",
+        "symfony/webpack-encore-bundle": "1.2.0||1.2.1",
+        "twig/twig": "2.6.1"
     },
     "scripts": {
         "symfony-scripts": [


### PR DESCRIPTION
Failing build:
https://travis-ci.com/github/ezsystems/ezplatform/builds/229620437

Error:
```
  Compile Error: Could not check compatibility between Symfony\Bridge\ProxyMa  
  nager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator::generate(Reflect  
  ionClass $originalClass, Zend\Code\Generator\ClassGenerator $classGenerator  
  ) and ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator::generate  
  (ReflectionClass $originalClass, Laminas\Code\Generator\ClassGenerator $cla  
  ssGenerator), because class Zend\Code\Generator\ClassGenerator is not avail  
  able    
```

Steps to reproduce:
`composer create-project ezsystems/ezplatform:^2.5@dev`

I've used PHP 7.4 and suspect that not all supported PHP versions are affects (see green build on PHP 7.1 in https://travis-ci.com/github/ezsystems/ezplatform/builds/229620437)

I've found that the issue is caused by the release of `laminas/laminas-code` 4.4.0 (released yesterday):
https://github.com/laminas/laminas-code/releases/tag/4.4.0

Installing this package version removes two other packages:
```
MacBook-Pro:test_laminas mareknocon$ composer require laminas/laminas-code:~4.4.0
./composer.json has been updated
Running composer update laminas/laminas-code
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 2 removals
  - Removing laminas/laminas-eventmanager (3.3.1)
  - Removing laminas/laminas-zendframework-bridge (1.2.0)
  - Upgrading laminas/laminas-code (4.3.0 => 4.4.0)
```

Based on the error message it looks like the error is caused by the lack of laminas-zendframework-bridge (https://github.com/laminas/laminas-zendframework-bridge/tree/1.3.x/src) which is adding some autoloading BC layer:
https://github.com/laminas/laminas-zendframework-bridge/blob/1.3.x/src/Autoloader.php#L117

The `Zend` namespace usage seems to come from symfony/proxy-manager-bridge:
https://github.com/symfony/proxy-manager-bridge/blob/3.4/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php#L15

needed by ez-support-tools:
```
MacBook-Pro:test_laminas mareknocon$ composer why symfony/proxy-manager-bridge
ezsystems/ez-support-tools  1.0.x-dev  requires  symfony/proxy-manager-bridge (^2.8.40 || ^3.4.11)
symfony/symfony             v3.4.49    replaces  symfony/proxy-manager-bridge (self.version)
```

It is possible to install `laminas/laminas-zendframework-bridge` alongside `laminas/laminas-code:4.4.0`: 
```
MacBook-Pro:test_laminas mareknocon$ composer require laminas/laminas-zendframework-bridge laminas/laminas-code:4.4.0
Using version ^1.2 for laminas/laminas-zendframework-bridge
./composer.json has been updated
Running composer update laminas/laminas-zendframework-bridge laminas/laminas-code
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 1 removal
  - Removing laminas/laminas-eventmanager (3.3.1)
  - Upgrading laminas/laminas-code (4.3.0 => 4.4.0)
```


I feel like the best way to solve this would to be to add `laminas/laminas-zendframework-bridge` to one of the dependencies that's using it (symfony/proxy-manager-bridge?), but TBH I don't see the big picture in this list of dependencies right now.

I've chosen to add a conflict as it's the quickest way to unblock Travis (and installation of development version of our product) - if you see a better way based on the data I've included here please let me know, I know that it will start failing as soon as laminas/laminas-code 4.4.1 is released.

Side:
Looks like removing `laminas/laminas-zendframework-bridge` would allow us to gain some performance (see: https://github.com/laminas/laminas-zendframework-bridge/issues/83), so we should probably stive to remove the conflict in the future.