### PR TITLE
[Travis] Added logging into Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_install: ./bin/.travis/trusty/update_docker.sh
 before_script:
   # Internal auth token dedicated to testing with travis+composer on ezsystems repos, not for reuse!
   - echo "{\"github-oauth\":{\"github.com\":\"d0285ed5c8644f30547572ead2ed897431c1fc09\"}}" > auth.json
+  # Login into Docker Hub to access Travis Docker images cache
+  - if [[ -n "${DOCKER_PASSWORD}" ]]; then echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin; fi
   # In case of dev mode we'll need to install composer packages first
   - docker-compose -f doc/docker/install.yml up --abort-on-container-exit
   # Run (start containers and execute install command)

--- a/bin/.travis/trusty/setup_from_external_repo.sh
+++ b/bin/.travis/trusty/setup_from_external_repo.sh
@@ -29,6 +29,11 @@ if [ "$COMPOSE_FILE" = "" ] ; then
     exit 1
 fi
 
+if [[ -n "${DOCKER_PASSWORD}" ]]; then
+    echo "> Set up Docker credentials"
+    echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+fi
+
 echo "> Move '$REPO_DIR' to 'tmp_travis_folder'"
 mv $REPO_DIR tmp_travis_folder
 ls -al tmp_travis_folder


### PR DESCRIPTION
Follow up to https://github.com/ezsystems/ezplatform/pull/644, which was done only for v2.5 or higher (but never for 1.13).

This change is needed in two places, as for external repos `bin/.travis/trusty/setup_from_external_repo.sh` is called, but for metarepo Docker is invoked directly.

Example failures:
https://travis-ci.com/github/ezsystems/ezplatform/jobs/517257672
https://travis-ci.com/github/ezsystems/ezpublish-kernel/jobs/517204307