### PR TITLE
[Composer] Added conflict with lexik/jwt-authentication-bundle 2.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
     },
     "conflict": {
         "doctrine/persistence": "1.3.2",
+        "lexik/jwt-authentication-bundle": "2.12.0",
         "symfony/framework-bundle": "5.1.0",
         "symfony/symfony": "*"
     },


### PR DESCRIPTION
Travis failure: https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/518410065#L2576

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  PHP Fatal error:  Class EzSystems\EzPlatformPageBuilder\Security\EditorialMode\TokenManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface::decodeFromJsonWebToken) in /var/www/vendor/ezsystems/ezplatform-page-builder/src/lib/Security/EditorialMode/TokenManager.php on line 24
!!  Symfony\Component\ErrorHandler\Error\FatalError {#10767
!!    -error: array:4 [
!!      "type" => 1
!!      "message" => "Class EzSystems\EzPlatformPageBuilder\Security\EditorialMode\TokenManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface::decodeFromJsonWebToken)"
!!      "file" => "/var/www/vendor/ezsystems/ezplatform-page-builder/src/lib/Security/EditorialMode/TokenManager.php"
!!      "line" => 24
!!    ]
!!    #message: "Error: Class EzSystems\EzPlatformPageBuilder\Security\EditorialMode\TokenManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface::decodeFromJsonWebToken)"
!!    #code: 0
!!    #file: "./vendor/ezsystems/ezplatform-page-builder/src/lib/Security/EditorialMode/TokenManager.php"
!!    #line: 24
!!  }
!!  
Script @auto-scripts was called via post-install-cmd
```

It's caused by the latest release in LexikJWTAuthenticationBundle, please see https://github.com/lexik/LexikJWTAuthenticationBundle/pull/872#issuecomment-866646057 for more information.

In theory we could only limit the dependency for ezplatform-ee, as this is the project where it breaks for us, but I think it's better to use the same bundle version across editions to avoid complications.