### PR TITLE
Remove conflict rule for lexik/jwt-authentication-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,6 @@
     },
     "conflict": {
         "doctrine/persistence": "1.3.2",
-        "lexik/jwt-authentication-bundle": "2.12.0",
         "symfony/framework-bundle": "5.1.0",
         "symfony/symfony": "*"
     },


### PR DESCRIPTION
Reverts #662. The BC break has been fixed in 2.12.1.
Note that you may want to implement the new `JWTTokenManagerInterface#parse()` method in your `TokenManager` implementation as it will be mandatory in 3.0.