### PR TITLE
[Composer] Added conflict with laminas/laminas-code:^4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/persistence": "1.3.2",
-        "laminas/laminas-code": "4.4.0",
+        "laminas/laminas-code": "^4.4",
         "symfony/symfony": "3.4.9||3.4.12||3.4.16",
         "symfony/webpack-encore-bundle": "1.2.0||1.2.1",
         "twig/twig": "2.6.1"


### PR DESCRIPTION
For a bigger picture please see first this PR:
https://github.com/ezsystems/ezplatform/pull/660

And the most important part:
```
I've chosen to add a conflict as it's the quickest way to unblock Travis (and installation of development version of our product) - if you see a better way based on the data I've included here please let me know, I know that it will start failing as soon as laminas/laminas-code 4.4.1 is released.
```
which happened this week:
https://github.com/laminas/laminas-code/releases

Given that this issue won't be solved upstream, as indicated in the disscusions:
https://github.com/laminas/laminas-code/issues/89
https://github.com/symfony/symfony/issues/41742

I think there's nothing we can do except for a conflict with all laminas/laminas-code in 4.4.x series and higher.