### PR TITLE
[Composer] Added laminas/laminas-zendframework-bridge requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "friendsofsymfony/jsrouting-bundle": "^1.6.3",
         "incenteev/composer-parameter-handler": "^2.1.3",
         "knplabs/knp-menu-bundle": "^2.2.1",
+        "laminas/laminas-zendframework-bridge": "^1.2",
         "monolog/monolog": "^1.25.2",
         "overblog/graphql-bundle": "^0.11.11",
         "scssphp/scssphp": "~1.0",
@@ -83,7 +84,6 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/persistence": "1.3.2",
-        "laminas/laminas-code": "^4.4",
         "symfony/symfony": "3.4.9||3.4.12||3.4.16",
         "symfony/webpack-encore-bundle": "1.2.0||1.2.1",
         "twig/twig": "2.6.1"


### PR DESCRIPTION
Travis failure:
https://app.travis-ci.com/github/ezsystems/ezplatform/jobs/536939186

ezplatform:^2.5@dev fails to install on PHP versions higher or equal to PHP 7.3 with error:
```
PHP Fatal error:  Could not check compatibility between Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator::generate(ReflectionClass $originalClass, Zend\Code\Generator\ClassGenerator $classGenerator) and ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator::generate(ReflectionClass $originalClass, Laminas\Code\Generator\ClassGenerator $classGenerator), because class Zend\Code\Generator\ClassGenerator is not available in /var/www/vendor/symfony/symfony/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php on line 25
```

You might remember that the same error happened in a previous Pull Request: https://github.com/ezsystems/ezplatform/pull/660 

More details:
https://github.com/symfony/symfony/issues/41742
https://github.com/laminas/laminas-code/issues/89

My understanding is as follows:
1) `symfony/proxy-manager-bridge` did not declare all the correct dependencies (it's missing `zendframework/zend-code`) . Ref: https://github.com/laminas/laminas-code/issues/89#issuecomment-863849240
2) Nothing will be done about it because it's reached EOL (https://github.com/symfony/symfony/issues/41742#issuecomment-863893222)
3) `zendframework/zend-code` got replaced by `laminas/laminas-code`
4) it is possible to use `laminas/laminas-code` and get it working if you add `laminas/laminas-zendframework-bridge` -> there's some autoloading magic that allows that (https://github.com/laminas/laminas-zendframework-bridge/blob/1.3.x/src/Autoloader.php#L106-L114)
5) This time the container stopped building because of a new version of `laminas/laminas-eventmanager`:
previous version (https://github.com/laminas/laminas-eventmanager/blob/3.3.1/composer.json#L27) has a dependency on `laminas/laminas-zendframework-bridge`, but the new one does not: https://github.com/laminas/laminas-eventmanager/blob/3.4.0/composer.json#L26

IMHO we have two options here:
1) Keep using `laminas/laminas-eventmanager`:3.3.1 (which adds the `laminas/laminas-zendframework-bridge` dependency)
2) Remove conflicts with laminas/* versions and add the `laminas/laminas-zendframework-bridge` package directly

I've decided to go with the second option, as IMHO adding more and more conflicts it not the way we want to go as it will make our maintenence harder.