### PR TITLE
[Composer] Lowered laminas/laminas-zendframework-bridge requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "friendsofsymfony/jsrouting-bundle": "^1.6.3",
         "incenteev/composer-parameter-handler": "^2.1.3",
         "knplabs/knp-menu-bundle": "^2.2.1",
-        "laminas/laminas-zendframework-bridge": "^1.2",
+        "laminas/laminas-zendframework-bridge": "^1.1",
         "monolog/monolog": "^1.25.2",
         "overblog/graphql-bundle": "^0.11.11",
         "scssphp/scssphp": "~1.0",


### PR DESCRIPTION
Quick follow-up to https://github.com/ezsystems/ezplatform/pull/666

`laminas/laminas-zendframework-bridge` with `^1.2` version constraint permits only PHP 7.3 or higher:
https://github.com/ezsystems/ezplatform/pull/666

eZ Platform 2.5 still supports PHP 7.1

Lowering to ^1.1 gives us the PHP 7.1 support:
https://github.com/laminas/laminas-zendframework-bridge/blob/1.1.x/composer.json#L18

Passing job running on PHP 7.1:
https://app.travis-ci.com/github/ezsystems/ezplatform/jobs/537498411