### PR TITLE
[Travis] Bumped default PHP version to 7.4 for browser tests

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.3-v2-node10
+PHP_IMAGE=ezsystems/php:7.4-v2-node10
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
 SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-20210422


### PR DESCRIPTION
Companion PR for https://github.com/ezsystems/ezplatform/pull/671

If we're switching to use PHP7.4 by default then it makes sense to test on that version by default as well.