### PR TITLE
[Travis] Added no-interaction flag

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -104,6 +104,6 @@ echo '> Change ownership of files inside docker container'
 docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 
 echo '> Install data'
-docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; composer ezplatform-install"
+docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; composer --no-interaction ezplatform-install"
 
 echo '> Done, ready to run tests'


### PR DESCRIPTION
The tests are currently faling:
https://app.travis-ci.com/github/ezsystems/ezplatform/builds/244323081
```
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] 

No output has been received in the last 30m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```

This is caused by the release of Composer 2.2, which does not run all plugins but only whitelisted ones:
https://blog.packagist.com/composer-2-2/

Adding --no-interaction seems enough for these tests to run

It's also mentioned in the release notes:
```
Please beware, the prompt may hang CI/build pipelines if they aren't using the --no-interaction (-n) option, as they should. (PR #10314)
```