### PR TITLE
IBX-1699: Bump requirement for Solr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ezsystems/ezplatform-http-cache": "^1.0@dev",
         "ezsystems/ezplatform-matrix-fieldtype": "^1.0@dev",
         "ezsystems/ezplatform-richtext": "^1.1@dev",
-        "ezsystems/ezplatform-solr-search-engine": "^1.6@dev",
+        "ezsystems/ezplatform-solr-search-engine": "^2.0@dev",
         "ezsystems/ezplatform-standard-design": "^0.2@dev",
         "ezsystems/ezplatform-user": "^1.0@dev",
         "ezsystems/ezpublish-kernel": "^7.5@dev",


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-1699

Since we can't upgrade Solr to 8.11.1 in ezplatform-solr-search-engine v1.7...
https://github.com/ezsystems/ezplatform-solr-search-engine/pull/226 (closed)

...we should upgrade eZ Platform v2.5 to ezplatform-solr-search-engine v2.0 instead, as it comes with Solr 7 and 8 support.