### PR TITLE
[Composer] Added allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,10 @@
         "sort-packages": true,
         "preferred-install": {
             "ezsystems/*": "dist"
+        },
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "symfony/thanks": true
         }
     },
     "extra": {


### PR DESCRIPTION
Adding allowed plugins to allow questions like:
```
  - Installing composer/package-versions-deprecated (1.11.99.4): Extracting archive
composer/package-versions-deprecated contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
  - Installing symfony/thanks (v1.2.10): Extracting archive
symfony/thanks contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/thanks" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
  - Installing behat/gherkin (v4.9.0): Extracting archive
```
during installation

V2 equivalent of https://github.com/ibexa/website-skeleton/pull/8