### PR TITLE
EZP-32437: EZP2.5 can't be installed on node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "@symfony/webpack-encore": "^0.28.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.0.1"
+  },
+  "resolutions": {
+    "sockjs-client": "1.5.2"
   }
 }


### PR DESCRIPTION
JIRA ref: https://issues.ibexa.co/browse/EZP-32437

Force to use older version of `sockjs-client` as newest release require node12