### PR TITLE
[CI] Set default project version to use in case of a non-PR build

### DIFF
--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -76,6 +76,14 @@ jobs:
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=varnish" >> $GITHUB_ENV
 
+            - id: project-version
+              name: "Set the project version to use"
+              run: |
+                echo "::set-output name=project-version::^2.5@dev"
+                if [[ -n "$GITHUB_BASE_REF" ]] ; then
+                    echo "::set-output name=project-version::${{ inputs.project-version }}"
+                fi
+
             - if: inputs.php-image != ''
               name: Create the PHP_IMAGE variable
               run: echo "PHP_IMAGE=${{ inputs.php-image }}" >> $GITHUB_ENV
@@ -90,7 +98,7 @@ jobs:
                   coverage: none
 
             - name: Set up metarepository
-              run: composer create-project ${{ inputs.project-edition }}:${{ inputs.project-version }} --no-install ${HOME}/build/ezplatform
+              run: composer create-project ${{ inputs.project-edition }}:${{ steps.project-version.outputs.project-version }} --no-install ${HOME}/build/ezplatform
 
             - if: env.SATIS_NETWORK_KEY != ''
               name: Add composer keys for private packagist


### PR DESCRIPTION
Example failure: https://github.com/ezsystems/ezplatform/actions/runs/2071282445

```
 Error: Could not find package ezsystems/ezplatform with version dev-.
                                                                  
  [InvalidArgumentException]                                      
  Could not find package ezsystems/ezplatform with version dev-. 
```

For Pull Requests to metarepository we need to use `project-version: "dev-${{ github.head_ref }}"` as the project version, so that changes from that Pull Request are taken into account when setting up the build.

For builds that are triggered after the Pull Request is merged the `dev-${{ github.head_ref }}` expression can't be used - because it's available only in Pull Request context.

The solution is simple:
- if the build is triggered by a PR then use the supplied inputs.project-version (overwrite the default value)
- if the build is triggered in any other way then use ^2.5@dev as the default value

It's based on `GITHUB_BASE_REF` env var, which is available only for Pull Request-triggered runs:
```
The name of the base ref or target branch of the pull request in a workflow run. This is only set when the event that triggers a workflow run is either pull_request or pull_request_target. For example, main.
```
(see: https://docs.github.com/en/actions/learn-github-actions/environment-variables)
