### PR TITLE
[CI] Increased Composer memory limit to 4G

### DIFF
--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -64,6 +64,7 @@ env:
     SYMFONY_ENV: behat
     SYMFONY_DEBUG: 1
     PHP_INI_ENV_memory_limit: 7G
+    COMPOSER_MEMORY_LIMIT: 4G
     ENABLE_XDEBUG: 1
 
 jobs:


### PR DESCRIPTION
Required by https://github.com/ezsystems/ezplatform-page-builder/pull/945 to have the demo installation passing.