### PR TITLE
IBX-2921: Disable TRACE/TRACK

### DIFF
--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -74,7 +74,7 @@
         RewriteEngine On
 
         # Make sure TRACE and TRACK methods are denied
-        RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
+        RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK) [NC]
         RewriteRule .* - [F]
 
         # For FastCGI mode or when using PHP-FPM, to get basic auth working.

--- a/doc/apache2/vhost.template
+++ b/doc/apache2/vhost.template
@@ -73,6 +73,10 @@
     <IfModule mod_rewrite.c>
         RewriteEngine On
 
+        # Make sure TRACE and TRACK methods are denied
+        RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
+        RewriteRule .* - [F]
+
         # For FastCGI mode or when using PHP-FPM, to get basic auth working.
         RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -6,7 +6,8 @@ server {
 
     root %BASEDIR%/web;
 
-    if ($request_method ~ ^(TRACE|TRACK)$) {
+    # Make sure TRACE and TRACK methods are denied
+    if ($request_method ~* ^(TRACE|TRACK)$) {
         return 405;
     }
 

--- a/doc/nginx/vhost.template
+++ b/doc/nginx/vhost.template
@@ -6,6 +6,10 @@ server {
 
     root %BASEDIR%/web;
 
+    if ($request_method ~ ^(TRACE|TRACK)$) {
+        return 405;
+    }
+
     # Additional Assetic rules
     ## Don't forget to run php bin/console assetic:dump --env=prod
     ## and make sure to comment these out in DEV environment.


### PR DESCRIPTION
Ref https://issues.ibexa.co/browse/IBX-2921

Disable TRACE/TRACK methods. Browsers have blocked this already for ages now, but explicitly blocking it in vhosts can silence some test warnings. Proposal by @vidarl, I just added case insensitivity. 