### PR TITLE
[Docker] Fixed varnish-modules installation

### DIFF
--- a/doc/docker/Dockerfile-varnish
+++ b/doc/docker/Dockerfile-varnish
@@ -32,9 +32,10 @@ RUN set -xe \
         && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish $buildDeps \
         \
     # Install varnish modules
-        && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://download.varnish-software.com/varnish-modules/varnish-modules-${VARNISH_MODULES_VERSION}.tar.gz \
+        && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://github.com/varnish/varnish-modules/archive/refs/tags/${VARNISH_MODULES_VERSION}.tar.gz \
         && tar zxpf /tmp/varnish-modules.tar.gz -C /tmp/ \
         && cd /tmp/varnish-modules-${VARNISH_MODULES_VERSION} \
+        && ./bootstrap \
         && ./configure \
         && make \
         # && make check \


### PR DESCRIPTION
Backport of https://github.com/ibexa/docker/pull/6

Failure: https://github.com/ezsystems/ezplatform-page-builder/actions/runs/3089020678/jobs/4996150584

Varnish fails to build:
```
+ curl -A Docker -o /tmp/varnish-modules.tar.gz -D - -L -s https://download.varnish-software.com/varnish-modules/varnish-modules-0.15.0.tar.gz
The command '/bin/sh -c set -xe         && buildDeps="             make             automake             autotools-dev             libedit-dev             libjemalloc-dev             libncurses-dev             libpcre3-dev             libtool             pkg-config             python-docutils             python-sphinx             varnish-dev         "         && apt-get update -q -y         && apt-get install -q -y --no-install-recommends ca-certificates curl bc net-tools                 && curl -s ${PACKAGECLOUD_URL} | bash         && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish $buildDeps                 && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s [https://download.varnish-software.com/varnish-modules/varnish-modules-${VARNISH_MODULES_VERSION}.tar.gz](https://download.varnish-software.com/varnish-modules/varnish-modules-$%7BVARNISH_MODULES_VERSION%7D.tar.gz)         && tar zxpf /tmp/varnish-modules.tar.gz -C /tmp/         && cd /tmp/varnish-modules-${VARNISH_MODULES_VERSION}         && ./configure         && make         && make install         && rm -f /tmp/varnish-modules.tar.gz && rm -Rf /tmp/varnish-modules                 && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps         && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 6
```