### PR TITLE
IBX-5077: Changed deprecated GitHub actions

### DIFF
--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -80,10 +80,9 @@ jobs:
             - id: project-version
               name: "Set the project version to use"
               run: |
-                echo "::set-output name=project-version::^2.5@dev"
+                echo "project-version=^2.5@dev" >> $GITHUB_OUTPUT
                 if [[ -n "$GITHUB_BASE_REF" ]] ; then
-                    echo "::set-output name=project-version::${{ inputs.project-version }}"
-                fi
+                    echo "project-version=${{ inputs.project-version }}" >> $GITHUB_OUTPUT
 
             - if: inputs.php-image != ''
               name: Create the PHP_IMAGE variable

--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -83,6 +83,7 @@ jobs:
                 echo "project-version=^2.5@dev" >> $GITHUB_OUTPUT
                 if [[ -n "$GITHUB_BASE_REF" ]] ; then
                     echo "project-version=${{ inputs.project-version }}" >> $GITHUB_OUTPUT
+                fi
 
             - if: inputs.php-image != ''
               name: Create the PHP_IMAGE variable

--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -69,7 +69,7 @@ env:
 
 jobs:
     browser-tests:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         timeout-minutes: ${{ inputs.timeout }}
 
         steps:
@@ -89,7 +89,7 @@ jobs:
               name: Create the PHP_IMAGE variable
               run: echo "PHP_IMAGE=${{ inputs.php-image }}" >> $GITHUB_ENV
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-5077
Github Actions has deprecated the set-output and save-state functions:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/