### PR TITLE
IBX-6383: Remove Allure reports integration from CI

### DIFF
--- a/.github/workflows/callable-browser-tests.yaml
+++ b/.github/workflows/callable-browser-tests.yaml
@@ -148,12 +148,6 @@ jobs:
                   cd ${HOME}/build/ezplatform
                   docker-compose --env-file=.env exec -T --user www-data app sh -c "bin/ezbehat ${{ inputs.test-suite }}"
 
-            - if: always()
-              name: Upload tests report
-              run: |
-                  cd ${HOME}/build/ezplatform
-                  bin/ezreport
-
     report-results:
         runs-on: ubuntu-latest
         timeout-minutes: 3

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -3,8 +3,6 @@ default:
         error_reporting: -1 # Report all PHP errors
     formatters:
         pretty: true
-        allure:
-          output_path: %paths.base%/build/allure
     extensions:
         Behat\MinkExtension:
             base_url: 'http://localhost'
@@ -44,9 +42,6 @@ default:
                     preset: ezplatform
                     mode: normal
                     limit: 10
-
-        Allure\Behat\AllureFormatterExtension:
-            image_attachment_limit: 5
 
     suites: ~
 

--- a/composer.json
+++ b/composer.json
@@ -71,8 +71,6 @@
         "behat/mink-selenium2-driver": "^1.4.0",
         "behat/symfony2-extension": "^2.1.5",
         "bex/behat-screenshot": "^1.2.7",
-        "ezsystems/allure-behat": "^2.0@dev",
-        "ezsystems/allure-php-api": "^2.0@dev",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0@dev",
         "ezsystems/behatbundle": "^7.0.0@dev",
         "liuggio/fastest": "~1.6.0",

--- a/doc/docker/Dockerfile-varnish
+++ b/doc/docker/Dockerfile-varnish
@@ -1,9 +1,9 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 ENV VARNISH_MALLOC_SIZE="256M" \
     DEBIAN_FRONTEND=noninteractive
 
-ARG PACKAGECLOUD_URL=https://packagecloud.io/install/repositories/varnishcache/varnish60/script.deb.sh
+ARG PACKAGECLOUD_URL=https://packagecloud.io/install/repositories/varnishcache/varnish60lts/script.deb.sh
 ARG VARNISH_MODULES_VERSION=0.15.0
 
 # Use official packages from Varnish and build with varnish-modules mainly for xkey
@@ -19,8 +19,8 @@ RUN set -xe \
             libpcre3-dev \
             libtool \
             pkg-config \
-            python-docutils \
-            python-sphinx \
+            python3-docutils \
+            sphinx-common \
             varnish-dev \
         " \
     # Update apt and get dependencies
@@ -29,7 +29,7 @@ RUN set -xe \
         \
     # Get official Varnish package
         && curl -s ${PACKAGECLOUD_URL} | bash \
-        && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish $buildDeps \
+        && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish=6.0.11-1~bullseye $buildDeps \
         \
     # Install varnish modules
         && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://github.com/varnish/varnish-modules/archive/refs/tags/${VARNISH_MODULES_VERSION}.tar.gz \


### PR DESCRIPTION
**JIRA**: [IBX-6383](https://issues.ibexa.co/browse/IBX-6383)

The goal of the task is to remove the whole Allure reports integration from our test code in order to shut the server hosting it down.

In case of v2.5 the PR also contains a back-port of an update of the docker file for Varnish (for the sake of a green CI build).