### PR TITLE
Fix for Release workflow

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -18,6 +18,9 @@ jobs:
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
 
+      - name: Install hub
+        run: sudo apt-get install -y hub
+
       # load current composer.lock
       - id: currentLock
         name: Gather latest package information


### PR DESCRIPTION
This fixes the issue, when changelog generator (aka Create Release workflow) will fail, since `hub` is unavailable at GitHub-hosted runners for some time.
